### PR TITLE
Transforms benchmarks experiment

### DIFF
--- a/examples/llm_compress_eval_example.py
+++ b/examples/llm_compress_eval_example.py
@@ -1,0 +1,145 @@
+from automation.pipelines import Pipeline
+from automation.tasks import LMEvalTask, LLMCompressorTask
+
+
+def get_quip_modifier(transform_block_size: int | None):
+    from llmcompressor.modifiers.transform import QuIPModifier
+
+    return QuIPModifier(
+        transform_type="hadamard", transform_block_size=transform_block_size
+    )
+
+
+def get_w4a16_scheme(group_size: int = 128):
+    from compressed_tensors.quantization import (
+        QuantizationScheme,
+        QuantizationStrategy,
+        QuantizationType,
+        QuantizationArgs,
+    )
+
+    return QuantizationScheme(
+        targets=["Linear"],
+        weights=QuantizationArgs(
+            num_bits=4,
+            type=QuantizationType.INT,
+            strategy=QuantizationStrategy.GROUP,
+            group_size=group_size,
+            symmetric=True,
+            dynamic=False,
+        ),
+    )
+
+
+def get_rtn_modifier(group_size: int = 128):
+    from llmcompressor.modifiers.quantization import (
+        QuantizationModifier,
+    )
+
+    # TODO: issue in llm-compressor when loading QuantizationModifiers from generated
+    # yaml --> Please specify either `targets` or `config_groups`
+    # manually delete for now
+    modifier = QuantizationModifier(
+        config_groups={"group_0": get_w4a16_scheme(group_size)}, ignore=["lm_head"]
+    )
+    modifier.targets = None
+    return modifier
+
+
+def get_gptq_modifier(group_size: int = 128):
+    from llmcompressor.modifiers.quantization import (
+        GPTQModifier,
+    )
+
+    modifier = GPTQModifier(
+        config_groups={"group_0": get_w4a16_scheme(group_size)}, ignore=["lm_head"]
+    )
+    modifier.targets = None
+    return modifier
+
+
+recipes = {
+    "RTN_W4A16G128": get_rtn_modifier(128),
+    "GPTQ_W4A16G128": get_gptq_modifier(128),
+    "QUIP_B128_RTN_W4A16G128": [get_quip_modifier(128), get_rtn_modifier(128)],
+    "QUIP_B128_GPTQ_W4A16G128": [get_quip_modifier(128), get_gptq_modifier(128)],
+    "QUIP_B64_RTN_W4A16G64": [get_quip_modifier(64), get_rtn_modifier(64)],
+    "QUIP_B64_GPTQ_W4A16G64": [get_quip_modifier(64), get_gptq_modifier(64)],
+}
+
+
+def average_scores(task):
+    gsm8k_score = task.get_reported_scalars()["gsm8k"]["exact_match,strict-match"]["y"][
+        0
+    ]
+    winogrande_score = task.get_reported_scalars()["winogrande"]["acc,none"]["y"][0]
+    average_score = (gsm8k_score + winogrande_score) / 2.0
+    task.get_logger().report_scalar(
+        title="score", series="average", iteration=0, value=average_score
+    )
+
+
+if __name__ == "__main__":
+    from llmcompressor.recipe import Recipe
+
+    pipeline = Pipeline(
+        project_name="brian_transforms",
+        pipeline_name="transforms_benchmark",
+        job_end_callback=average_scores,
+    )
+
+    for model_id in [
+        "meta-llama/Llama-3.2-3B-Instruct",
+        # "meta-llama/Llama-3.1-8B-Instruct",
+    ]:
+        for recipe_id, recipe_modifiers in recipes.items():
+            # NOTE: passing recipe in as a list of modifiers results in parsing
+            # errors. Use `Recipe.from_modifiers(recipe).model_dump_json()` instead
+            recipe = Recipe.from_modifiers(recipe_modifiers)
+            compress_step_name = f"compress-{recipe_id}"
+            compress_step = LLMCompressorTask(
+                project_name="brian_transforms",
+                task_name=compress_step_name,
+                model_id=model_id,
+                text_samples=512,
+                recipe=recipe.yaml(),
+            )
+            compress_step.create_task()
+
+            eval_step = LMEvalTask(
+                project_name="brian_transforms",
+                task_name=f"eval-{recipe_id}",
+                model_id="dummuy",  # overridden
+                clearml_model=True,
+                tasks=["gsm8k", "winogrande"],
+                num_fewshot=5,
+                # limit=10,
+            )
+            eval_step.create_task()
+
+            pipeline.add_step(
+                name=compress_step_name,
+                base_task_id=compress_step.id,
+                execution_queue="oneshot-a100x1",
+                monitor_models=[
+                    compress_step.get_arguments()["Args"]["save_directory"]
+                ],
+                monitor_artifacts=["recipe"],
+            )
+
+            pipeline.add_step(
+                name=f"eval-{recipe_id}",
+                base_task_id=eval_step.id,
+                parents=[compress_step_name],
+                execution_queue="oneshot-a100x1",
+                parameter_override={
+                    "Args/model_id": "${" + compress_step_name + ".models.output.-1.id}"
+                },
+                monitor_metrics=[
+                    ("gsm8k", "exact_match,strict-match"),
+                    ("winogrande", "acc,none"),
+                ],
+            )
+
+    pipeline.start()
+    # pipeline.execute_locally()

--- a/examples/llm_compress_eval_example.py
+++ b/examples/llm_compress_eval_example.py
@@ -74,7 +74,7 @@ def get_gptq_modifier(group_size: int = 128):
 
 
 recipes = {
-    "DENSE": [],
+    # "DENSE": [],
     # "RTN_W4A16G128": get_rtn_modifier(128),
     # "GPTQ_W4A16G128": get_gptq_modifier(128),
     # "QUIPv_B128_RTN_W4A16G128": [get_quip_modifier(128, ["v"]), get_rtn_modifier(128)],

--- a/examples/llm_compress_eval_example.py
+++ b/examples/llm_compress_eval_example.py
@@ -1,12 +1,23 @@
 from typing import Literal
 from clearml import Task
 
-# TODO: cannot use PipelineController, fails to clone github.com:neuralmagic/research
-# from clearml import PipelineController
 from automation.pipelines import Pipeline
 from automation.tasks import LMEvalTask, LLMCompressorTask
 
 PROJECT_NAME = "brian_transforms_v1"
+
+
+def get_spinquant_modifier(
+    transform_block_size: int | None,
+    rotations: list[Literal["R1", "R2", "R4"]] = ["R1", "R2"],
+):
+    from llmcompressor.modifiers.transform import SpinQuantModifier
+
+    return SpinQuantModifier(
+        transform_type="hadamard",
+        transform_block_size=transform_block_size,
+        rotations=rotations,
+    )
 
 
 def get_quip_modifier(
@@ -75,8 +86,16 @@ recipes = {
     #     get_quip_modifier(128, ["u", "v"]),
     #     get_rtn_modifier(128),
     # ],
-    "QUIPuv_B128_GPTQ_W4A16G128": [
-        get_quip_modifier(128, ["u", "v"]),
+    # "QUIPuv_B128_GPTQ_W4A16G128": [
+    #     get_quip_modifier(128, ["u", "v"]),
+    #     get_gptq_modifier(128),
+    # ],
+    "SpinQuantR1R2_B128_GPTQ_W4A16G128": [
+        get_spinquant_modifier(128, ["R1", "R2"]),
+        get_gptq_modifier(128),
+    ],
+    "SpinQuantR1R2R4_B128_GPTQ_W4A16G128": [
+        get_spinquant_modifier(128, ["R1", "R2", "R4"]),
         get_gptq_modifier(128),
     ],
     # "RTN_W4A16G64": get_rtn_modifier(64),
@@ -87,8 +106,16 @@ recipes = {
     #     get_gptq_modifier(64),
     # ],
     # "QUIPuv_B64_RTN_W4A16G64": [get_quip_modifier(64, ["u", "v"]), get_rtn_modifier(64)],
-    "QUIPuv_B64_GPTQ_W4A16G64": [
-        get_quip_modifier(64, ["u", "v"]),
+    # "QUIPuv_B64_GPTQ_W4A16G64": [
+    #     get_quip_modifier(64, ["u", "v"]),
+    #     get_gptq_modifier(64),
+    # ],
+    "SpinQuantR1R2_B64_GPTQ_W4A16G64": [
+        get_spinquant_modifier(64, ["R1", "R2"]),
+        get_gptq_modifier(64),
+    ],
+    "SpinQuantR1R2R4_B64_GPTQ_W4A16G64": [
+        get_spinquant_modifier(64, ["R1", "R2", "R4"]),
         get_gptq_modifier(64),
     ],
     # "RTN_W4A16G32": get_rtn_modifier(32),
@@ -99,8 +126,16 @@ recipes = {
     #     get_gptq_modifier(32),
     # ],
     # "QUIPuv_B32_RTN_W4A16G32": [get_quip_modifier(32, ["u", "v"]), get_rtn_modifier(32)],
-    "QUIPuv_B32_GPTQ_W4A16G32": [
-        get_quip_modifier(32, ["u", "v"]),
+    # "QUIPuv_B32_GPTQ_W4A16G32": [
+    #     get_quip_modifier(32, ["u", "v"]),
+    #     get_gptq_modifier(32),
+    # ],
+    "SpinQuantR1R2_B32_GPTQ_W4A16G32": [
+        get_spinquant_modifier(32, ["R1", "R2"]),
+        get_gptq_modifier(32),
+    ],
+    "SpinQuantR1R2R4_B32_GPTQ_W4A16G32": [
+        get_spinquant_modifier(32, ["R1", "R2", "R4"]),
         get_gptq_modifier(32),
     ],
 }
@@ -193,4 +228,3 @@ if __name__ == "__main__":
             )
 
     pipeline.execute_remotely()
-    # pipeline.execute_locally()

--- a/examples/llm_compress_eval_example.py
+++ b/examples/llm_compress_eval_example.py
@@ -47,14 +47,9 @@ def get_rtn_modifier(group_size: int = 128):
         QuantizationModifier,
     )
 
-    # TODO: issue in llm-compressor when loading QuantizationModifiers from generated
-    # yaml --> Please specify either `targets` or `config_groups`
-    # manually delete for now
-    modifier = QuantizationModifier(
+    return QuantizationModifier(
         config_groups={"group_0": get_w4a16_scheme(group_size)}, ignore=["lm_head"]
     )
-    modifier.targets = None
-    return modifier
 
 
 def get_gptq_modifier(group_size: int = 128):
@@ -62,40 +57,52 @@ def get_gptq_modifier(group_size: int = 128):
         GPTQModifier,
     )
 
-    modifier = GPTQModifier(
+    return GPTQModifier(
         config_groups={"group_0": get_w4a16_scheme(group_size)}, ignore=["lm_head"]
     )
-    modifier.targets = None
-    return modifier
 
 
 recipes = {
-    "RTN_W4A16G128": get_rtn_modifier(128),
-    "GPTQ_W4A16G128": get_gptq_modifier(128),
-    "QUIPv_B128_RTN_W4A16G128": [get_quip_modifier(128, ["v"]), get_rtn_modifier(128)],
-    "QUIPv_B128_GPTQ_W4A16G128": [
-        get_quip_modifier(128, ["v"]),
+    "DENSE": [],
+    # "RTN_W4A16G128": get_rtn_modifier(128),
+    # "GPTQ_W4A16G128": get_gptq_modifier(128),
+    # "QUIPv_B128_RTN_W4A16G128": [get_quip_modifier(128, ["v"]), get_rtn_modifier(128)],
+    # "QUIPv_B128_GPTQ_W4A16G128": [
+    #     get_quip_modifier(128, ["v"]),
+    #     get_gptq_modifier(128),
+    # ],
+    # "QUIPuv_B128_RTN_W4A16G128": [
+    #     get_quip_modifier(128, ["u", "v"]),
+    #     get_rtn_modifier(128),
+    # ],
+    "QUIPuv_B128_GPTQ_W4A16G128": [
+        get_quip_modifier(128, ["u", "v"]),
         get_gptq_modifier(128),
     ],
-    "RTN_W4A16G64": get_rtn_modifier(64),
-    "GPTQ_W4A16G64": get_gptq_modifier(64),
-    "QUIPv_B64_RTN_W4A16G64": [get_quip_modifier(64, ["v"]), get_rtn_modifier(64)],
-    "QUIPv_B64_GPTQ_W4A16G64": [
-        get_quip_modifier(64, ["v"]),
+    # "RTN_W4A16G64": get_rtn_modifier(64),
+    # "GPTQ_W4A16G64": get_gptq_modifier(64),
+    # "QUIPv_B64_RTN_W4A16G64": [get_quip_modifier(64, ["v"]), get_rtn_modifier(64)],
+    # "QUIPv_B64_GPTQ_W4A16G64": [
+    #     get_quip_modifier(64, ["v"]),
+    #     get_gptq_modifier(64),
+    # ],
+    # "QUIPuv_B64_RTN_W4A16G64": [get_quip_modifier(64, ["u", "v"]), get_rtn_modifier(64)],
+    "QUIPuv_B64_GPTQ_W4A16G64": [
+        get_quip_modifier(64, ["u", "v"]),
         get_gptq_modifier(64),
     ],
-    "RTN_W4A16G32": get_rtn_modifier(32),
-    "GPTQ_W4A16G32": get_gptq_modifier(32),
-    "QUIPv_B32_RTN_W4A16G32": [get_quip_modifier(32, ["v"]), get_rtn_modifier(32)],
-    "QUIPv_B32_GPTQ_W4A16G32": [
-        get_quip_modifier(32, ["v"]),
+    # "RTN_W4A16G32": get_rtn_modifier(32),
+    # "GPTQ_W4A16G32": get_gptq_modifier(32),
+    # "QUIPv_B32_RTN_W4A16G32": [get_quip_modifier(32, ["v"]), get_rtn_modifier(32)],
+    # "QUIPv_B32_GPTQ_W4A16G32": [
+    #     get_quip_modifier(32, ["v"]),
+    #     get_gptq_modifier(32),
+    # ],
+    # "QUIPuv_B32_RTN_W4A16G32": [get_quip_modifier(32, ["u", "v"]), get_rtn_modifier(32)],
+    "QUIPuv_B32_GPTQ_W4A16G32": [
+        get_quip_modifier(32, ["u", "v"]),
         get_gptq_modifier(32),
     ],
-    # TODO: Quip U rotations broken in vllm only in clearml env, cannot reproduce locally
-    # "QUIPu_B128_RTN_W4A16G128": [get_quip_modifier(128, ["u"]), get_rtn_modifier(128)],
-    # "QUIPu_B128_GPTQ_W4A16G128": [get_quip_modifier(128, ["u"]), get_gptq_modifier(128)],
-    # "QUIP_B64_RTN_W4A16G64": [get_quip_modifier(64), get_rtn_modifier(64)],
-    # "QUIP_B64_GPTQ_W4A16G64": [get_quip_modifier(64), get_gptq_modifier(64)],
 }
 
 

--- a/src/automation/tasks/base_task.py
+++ b/src/automation/tasks/base_task.py
@@ -112,6 +112,11 @@ class BaseTask():
             repo="https://github.com/neuralmagic/research.git",
             branch=self.branch,
         )
+        # To avoid precompiling VLLM when installing from main, add env var
+        self.task.set_base_docker(
+            docker_image=self.docker_image,
+            docker_arugments="-e VLLM_USE_PRECOMPILED=1",
+        )
         self.task.output_uri = DEFAULT_OUTPUT_URI
         self.set_arguments()
         self.set_configurations()

--- a/src/automation/tasks/llmcompressor.py
+++ b/src/automation/tasks/llmcompressor.py
@@ -13,6 +13,8 @@ class LLMCompressorTask(BaseTask):
         "torchvision==0.23.0",
         "huggingface-hub>=0.34.0,<1.0",
         "hf_xet",
+        # Will error out for networkx v3.5+, which has python-requires>=3.11
+        "networkx~=3.4.2",
     ]
 
     def __init__(

--- a/src/automation/tasks/lmeval.py
+++ b/src/automation/tasks/lmeval.py
@@ -8,7 +8,9 @@ import os
 class LMEvalTask(BaseTask):
 
     task_packages = [
-        "vllm",
+        # Use latest vllm release or install from main
+        # "vllm",
+        "git+https://github.com/vllm-project/vllm.git",
         "git+https://github.com/EleutherAI/lm-evaluation-harness.git",
         "numpy==2.1",
         "huggingface-hub>=0.34.0,<1.0",

--- a/src/automation/tasks/lmeval.py
+++ b/src/automation/tasks/lmeval.py
@@ -4,12 +4,14 @@ from automation.utils import merge_dicts
 from typing import Optional, Sequence
 import os
 
+
 class LMEvalTask(BaseTask):
 
     task_packages = [
         "vllm",
         "git+https://github.com/EleutherAI/lm-evaluation-harness.git",
         "numpy==2.1",
+        "huggingface-hub>=0.34.0,<1.0",
         "hf_xet",
         "rouge-score",
         "bert-score",
@@ -21,13 +23,13 @@ class LMEvalTask(BaseTask):
         project_name: str,
         task_name: str,
         model_id: str,
-        docker_image: str=DEFAULT_DOCKER_IMAGE,
-        packages: Optional[Sequence[str]]=None,
-        clearml_model: bool=False,
-        task_type: str="training",
-        force_download: bool=False,
-        config: Optional[str]=None,
-        model: str="vllm",
+        docker_image: str = DEFAULT_DOCKER_IMAGE,
+        packages: Optional[Sequence[str]] = None,
+        clearml_model: bool = False,
+        task_type: str = "training",
+        force_download: bool = False,
+        config: Optional[str] = None,
+        model: str = "vllm",
         **kwargs,
     ):
 
@@ -43,7 +45,9 @@ class LMEvalTask(BaseTask):
                 if "vllm" in package:
                     self.task_packages.pop("vllm")
                 if "lm-evaluation-harness" in package:
-                    self.task_packages.pop("git+https://github.com/EleutherAI/lm-evaluation-harness.git")
+                    self.task_packages.pop(
+                        "git+https://github.com/EleutherAI/lm-evaluation-harness.git"
+                    )
             packages = list(set(packages + self.task_packages))
         else:
             packages = self.task_packages
@@ -67,7 +71,9 @@ class LMEvalTask(BaseTask):
                 continue
 
             if key in kwargs:
-                raise ValueError(f"{key} already defined in config's model_args. It can't be defined again in task instantiation.")
+                raise ValueError(
+                    f"{key} already defined in config's model_args. It can't be defined again in task instantiation."
+                )
             elif key == "model":
                 model = config_kwargs.pop(key)
 
@@ -75,12 +81,16 @@ class LMEvalTask(BaseTask):
         # in both the config and in the constructor, assuming
         # the keys used in model_args are complementary
         if "model_args" in kwargs:
-            model_args = dict(item.split("=") for item in kwargs.pop("model_args").split(","))
+            model_args = dict(
+                item.split("=") for item in kwargs.pop("model_args").split(",")
+            )
         else:
             model_args = {}
 
         if "model_args" in config_kwargs:
-            config_model_args = dict(item.split("=") for item in config_kwargs.pop("model_args").split(","))
+            config_model_args = dict(
+                item.split("=") for item in config_kwargs.pop("model_args").split(",")
+            )
             model_args = merge_dicts(model_args, config_model_args)
 
         # Set default dtype and enable_chunked_prefill
@@ -94,7 +104,7 @@ class LMEvalTask(BaseTask):
             model_args["enforce_eager"] = True
 
         kwargs["model_args"] = ",".join(f"{k}={v}" for k, v in model_args.items())
-        
+
         kwargs.update(config_kwargs)
         kwargs["model"] = model
 
@@ -103,19 +113,19 @@ class LMEvalTask(BaseTask):
         self.clearml_model = clearml_model
         self.lm_eval = kwargs
         self.force_download = force_download
-        self.script_path = os.path.join(".", "src", "automation", "tasks", "scripts", "lmeval_script.py")
-
+        self.script_path = os.path.join(
+            ".", "src", "automation", "tasks", "scripts", "lmeval_script.py"
+        )
 
     def script(self, configurations, args):
         from automation.tasks.scripts.lmeval_script import main
-        main(configurations, args)
 
+        main(configurations, args)
 
     def get_configurations(self):
         return {
             "lm_eval": self.lm_eval,
         }
-
 
     def get_arguments(self):
         return {


### PR DESCRIPTION
This PR leverages the pre-built tasks `LLMCompresorTask` and `LMEvalTask` to create an example script to run several llm-compressor recipes at a time, in a single pipeline, in parallel. Each model is then run through an evaluation using `lm_eval`. Results available at https://spaces.redhat.com/spaces/vLLM/pages/714211727/Transforms+Benchmarks+v1

- [x] I had to make a few updates, pinning dependency versions so that they would install correctly in clearml, based on feedback from @Chibukach 
- [x] I added some logic to make sure the LMEvalTask installs vllm with `VLLM_USE_PRECOMIPLED=1`. This was needed to run an experiment with a transforms feature on main that hadn't been released yet. I think we want to always do this, but I can move it to an input to the `LMEvalTask` constructor if that is preferred.