### PR TITLE
Simplify OpenShift benchmark examples: Qwen3-8B, drop Cohere deps

### DIFF
--- a/openshift/bfcl/README.md
+++ b/openshift/bfcl/README.md
@@ -1,8 +1,7 @@
 # BFCL v4 on OpenShift
 
 Tool calling benchmarks using the
-[Berkeley Function Calling Leaderboard](https://github.com/ShishirPatil/gorilla)
-for evaluating FP8 quantization recovery on Command A+.
+[Berkeley Function Calling Leaderboard](https://github.com/ShishirPatil/gorilla).
 
 Each benchmark runs as a Kubernetes **Job** with two containers on an H100 node:
 - **vllm-server** — serves the model on port 8000 with `--served-model-name`
@@ -14,20 +13,25 @@ Each benchmark runs as a Kubernetes **Job** with two containers on an H100 node:
 > your identifier before applying. This affects the Job name, secret references,
 > and PVC claim names.
 
-## Presets
+## Example model
 
-`bfcl.yml` ships configured for FP8. To switch presets, update the lines
-marked with `✎` in the YAML:
+`bfcl.yml` ships configured for **Qwen3-8B** on a single GPU as a lightweight
+example. To use a different model, update the lines marked with `✎` in the YAML:
 
-| Field | FP8 (default) | BF16 baseline |
-|-------|---------------|---------------|
-| Job name suffix | `-bfcl-fp8` | `-bfcl-bf16` |
-| `MODEL_ID` / `MODEL` | `RedHatAI/command-a-plus-05-2026-fp8` | `CohereLabs/command-a-plus-05-2026-bf16` |
-| `QUANTIZATION` | `fp8` | `bf16` |
-| `NUM_THREADS` | `12` | `8` |
+| Field | What to change |
+|-------|----------------|
+| Job name suffix | Match your model/quantization |
+| `MODEL_ID` / `MODEL` | HuggingFace model ID |
+| `QUANTIZATION` | `fp8`, `bf16`, etc. |
+| `NUM_THREADS` | Scale to model throughput |
+| GPU requests/limits | Scale to model size |
 
-`NUM_THREADS` is tuned to model size — the smaller FP8 model handles more
-concurrent requests, so it gets more benchmark threads.
+For larger models, also increase the tier1 ephemeral storage and adjust
+`--tensor-parallel-size` / `--data-parallel-size` in the vllm-server script.
+
+For models that require a specific tool-call parser, add
+`--tool-call-parser <parser>` to the `vllm serve` command in the vllm-server
+script (e.g. `--tool-call-parser hermes`).
 
 ## Prerequisites
 
@@ -57,23 +61,23 @@ oc apply -f bfcl.yml
 
 ```bash
 # Find the pod created by the Job
-oc get pods -l app.kubernetes.io/instance=mlr-vllm-<YOUR_NAME>-bfcl-fp8
+oc get pods -l app.kubernetes.io/instance=mlr-vllm-<YOUR_NAME>-bfcl
 
 # Server logs
-oc logs -l app.kubernetes.io/instance=mlr-vllm-<YOUR_NAME>-bfcl-fp8 -c vllm-server -f
+oc logs -l app.kubernetes.io/instance=mlr-vllm-<YOUR_NAME>-bfcl -c vllm-server -f
 
 # Benchmark logs
-oc logs -l app.kubernetes.io/instance=mlr-vllm-<YOUR_NAME>-bfcl-fp8 -c benchmark -f
+oc logs -l app.kubernetes.io/instance=mlr-vllm-<YOUR_NAME>-bfcl -c benchmark -f
 ```
 
 ### Clean up
 
 ```bash
 # By name
-oc delete job mlr-vllm-<YOUR_NAME>-bfcl-fp8 -n machine-learning
+oc delete job mlr-vllm-<YOUR_NAME>-bfcl -n machine-learning
 
 # Or by label
-oc delete all -l app.kubernetes.io/instance=mlr-vllm-<YOUR_NAME>-bfcl-fp8 -n machine-learning
+oc delete all -l app.kubernetes.io/instance=mlr-vllm-<YOUR_NAME>-bfcl -n machine-learning
 ```
 
 ## What it benchmarks
@@ -109,7 +113,7 @@ Each run produces a timestamped directory under `/tier2/benchmark_results/` cont
 
 ### Model
 
-To use a different model entirely, update the `MODEL_ID` / `MODEL` variables
+To use a different model, update the `MODEL_ID` / `MODEL` variables
 (marked `✎`) in both container scripts. The `--served-model-name` must match
 the model name registered in BFCL.
 
@@ -125,4 +129,5 @@ bfcl test-categories
 
 ### GPU count
 
-The YAML requests 8 GPUs. TP and DP are set in the vllm-server script.
+The YAML requests 1 GPU by default. Update `nvidia.com/gpu` in the vllm-server
+container's resources to match your model's requirements.

--- a/openshift/bfcl/bfcl.yml
+++ b/openshift/bfcl/bfcl.yml
@@ -3,32 +3,26 @@
 #   1. metadata.name          (Job + label)
 #   2. MODEL_ID / MODEL       (in each container script)
 #   3. QUANTIZATION            (in the benchmark script)
-#   4. NUM_THREADS             (scale to model size — see table)
+#   4. NUM_THREADS             (scale to model size)
 #
-# ┌────────────────────────────────────────────────────────────────────┐
-# │  Preset   │ MODEL_ID                                │ Q   │ Thr  │
-# ├───────────┼─────────────────────────────────────────┼─────┼──────┤
-# │  FP8      │ RedHatAI/command-a-plus-05-2026-fp8     │ fp8 │  12  │
-# │  BF16     │ CohereLabs/command-a-plus-05-2026-bf16  │ bf16│   8  │
-# └────────────────────────────────────────────────────────────────────┘
-# NUM_THREADS: FP8 is smaller and handles more concurrent requests,
-# so it gets more benchmark threads than BF16.
+# The example below uses Qwen3-8B on a single GPU. Adjust GPU count,
+# TP, and tier1 storage when serving larger models.
 # ──────────────────────────────────────────────────────────────────────
 apiVersion: batch/v1
 kind: Job
 metadata:
-  # ✎ Change suffix to match quantization (e.g. -bfcl-fp8 or -bfcl-bf16)
-  name: mlr-vllm-<YOUR_NAME>-bfcl-fp8
+  # ✎ Change suffix to match your model/quantization
+  name: mlr-vllm-<YOUR_NAME>-bfcl
   namespace: machine-learning
   labels:
-    app.kubernetes.io/instance: mlr-vllm-<YOUR_NAME>-bfcl-fp8
+    app.kubernetes.io/instance: mlr-vllm-<YOUR_NAME>-bfcl
 spec:
   backoffLimit: 0
   activeDeadlineSeconds: 43200
   template:
     metadata:
       labels:
-        app.kubernetes.io/instance: mlr-vllm-<YOUR_NAME>-bfcl-fp8
+        app.kubernetes.io/instance: mlr-vllm-<YOUR_NAME>-bfcl
     spec:
       restartPolicy: Never
       serviceAccountName: ml-workload
@@ -50,9 +44,7 @@ spec:
             set -e
 
             # ✎ Model to serve
-            MODEL_ID="RedHatAI/command-a-plus-05-2026-fp8"
-
-            pip install -q cohere_melody>=0.9.0
+            MODEL_ID="Qwen/Qwen3-8B"
 
             export HF_HOME="/tier2/hf-hub"
             export HF_HUB_CACHE="/tier2/hf-hub"
@@ -88,15 +80,13 @@ spec:
                 --served-model-name "$MODEL_ID" \
                 --tensor-parallel-size ${NUM_GPUS} \
                 --data-parallel-size 1 \
-                --tool-call-parser cohere_command4 \
-                --reasoning-parser cohere_command4 \
                 --enable-auto-tool-choice \
                 --port 8000
         resources:
           requests:
-            nvidia.com/gpu: 8
+            nvidia.com/gpu: 1
           limits:
-            nvidia.com/gpu: 8
+            nvidia.com/gpu: 1
         env:
         - name: HF_TOKEN
           valueFrom:
@@ -133,8 +123,8 @@ spec:
             set -e
 
             # ✎ Benchmark configuration
-            MODEL="RedHatAI/command-a-plus-05-2026-fp8"
-            QUANTIZATION="fp8"
+            MODEL="Qwen/Qwen3-8B"
+            QUANTIZATION="bf16"
             NUM_THREADS=12
             BFCL_CATEGORIES="non_live multi_turn"
 
@@ -257,11 +247,9 @@ spec:
                     'image': 'vllm/vllm-openai:v0.22.1',
                     'model': '${MODEL}',
                     'max_model_len': None,
-                    'tensor_parallel_size': 8,
+                    'tensor_parallel_size': 1,
                     'data_parallel_size': 1,
                     'served_model_name': '${MODEL}',
-                    'tool_call_parser': 'cohere_command4',
-                    'reasoning_parser': 'cohere_command4',
                     'models_endpoint': json.loads('''${SERVER_MODELS}'''),
                 },
                 'client': {
@@ -365,7 +353,7 @@ spec:
               storageClassName: lvms-h100-tier1-storage
               resources:
                 requests:
-                  storage: 512Gi
+                  storage: 50Gi
       - name: tier2
         persistentVolumeClaim:
           claimName: mlr-tier2-<YOUR_NAME>

--- a/openshift/lm-eval/README.md
+++ b/openshift/lm-eval/README.md
@@ -1,8 +1,7 @@
 # lm-eval on OpenShift
 
 Accuracy benchmarks using
-[lm-evaluation-harness](https://github.com/EleutherAI/lm-evaluation-harness)
-for evaluating FP8 quantization recovery on Command A+.
+[lm-evaluation-harness](https://github.com/EleutherAI/lm-evaluation-harness).
 
 Uses the [neuralmagic fork](https://github.com/neuralmagic/lm-evaluation-harness/tree/mmlu-pro-chat-variant)
 which adds the `mmlu_pro_chat` task variant.
@@ -10,17 +9,18 @@ which adds the `mmlu_pro_chat` task variant.
 > **Note:** Replace all occurrences of `<YOUR_NAME>` in the YAML with
 > your identifier before applying.
 
-## Presets
+## Example model
 
-`lm-eval.yml` ships configured for FP8. To switch presets, update the lines
-marked with `✎` in the YAML:
+`lm-eval.yml` ships configured for **Qwen3-8B** on a single GPU as a lightweight
+example. To use a different model, update the lines marked with `✎` in the YAML:
 
-| Field | FP8 (default) | BF16 baseline |
-|-------|---------------|---------------|
-| Job name suffix | `-lm-eval-fp8` | `-lm-eval-bf16` |
-| `MODEL_ID` / `MODEL` | `RedHatAI/command-a-plus-05-2026-fp8` | `CohereLabs/command-a-plus-05-2026-bf16` |
-| `QUANTIZATION` | `fp8` | `bf16` |
-| `TP` / `DP` | `4` / `2` | `8` / `1` |
+| Field | What to change |
+|-------|----------------|
+| Job name suffix | Match your model/quantization |
+| `MODEL_ID` / `MODEL` | HuggingFace model ID |
+| `QUANTIZATION` | `fp8`, `bf16`, etc. |
+| `TP` / `DP` | Scale to model size |
+| GPU requests/limits | Scale to model size |
 
 ## Tasks
 
@@ -33,7 +33,7 @@ The sweep runs 4 tasks across 3 seeds (0, 1, 2) for statistical robustness:
 | `ifeval` | 0-shot | Instruction following evaluation |
 | `mmlu_cot_llama` | 5-shot | MMLU with chain-of-thought, few-shot as multi-turn |
 
-All tasks use `temperature=0.6`, `top_p=0.95`, `max_gen_toks=65536`.
+All tasks use `temperature=0.6`, `top_p=0.95`, `max_gen_toks=32768`.
 
 ## Usage
 
@@ -41,14 +41,24 @@ All tasks use `temperature=0.6`, `top_p=0.95`, `max_gen_toks=65536`.
 oc apply -f lm-eval.yml
 ```
 
+### Quick validation run
+
+Set `LIMIT=N` on the benchmark container to cap samples per task:
+
+```bash
+oc set env job/mlr-vllm-<YOUR_NAME>-lm-eval LIMIT=10 -c benchmark
+```
+
+Or edit `lm-eval.yml` to add the env var before applying.
+
 ### Monitor progress
 
 ```bash
-oc logs -l app.kubernetes.io/instance=mlr-vllm-<YOUR_NAME>-lm-eval-fp8 -c benchmark -f
+oc logs -l app.kubernetes.io/instance=mlr-vllm-<YOUR_NAME>-lm-eval -c benchmark -f
 ```
 
 ### Clean up
 
 ```bash
-oc delete job mlr-vllm-<YOUR_NAME>-lm-eval-fp8 -n machine-learning
+oc delete job mlr-vllm-<YOUR_NAME>-lm-eval -n machine-learning
 ```

--- a/openshift/lm-eval/lm-eval.yml
+++ b/openshift/lm-eval/lm-eval.yml
@@ -5,28 +5,24 @@
 #   3. QUANTIZATION            (in the benchmark script)
 #   4. TP / DP                 (in the vllm-server script)
 #
-# ┌────────────────────────────────────────────────────────────────────┐
-# │  Preset   │ MODEL_ID                                │ Q   │TP│DP │
-# ├───────────┼─────────────────────────────────────────┼─────┼──┼───┤
-# │  FP8      │ RedHatAI/command-a-plus-05-2026-fp8     │ fp8 │ 4│ 2 │
-# │  BF16     │ CohereLabs/command-a-plus-05-2026-bf16  │ bf16│ 8│ 1 │
-# └────────────────────────────────────────────────────────────────────┘
+# The example below uses Qwen3-8B on a single GPU. Adjust GPU count,
+# TP/DP, and tier1 storage when serving larger models.
 # ──────────────────────────────────────────────────────────────────────
 apiVersion: batch/v1
 kind: Job
 metadata:
-  # ✎ Change suffix to match quantization (e.g. -lm-eval-fp8 or -lm-eval-bf16)
-  name: mlr-vllm-<YOUR_NAME>-lm-eval-fp8
+  # ✎ Change suffix to match your model/quantization
+  name: mlr-vllm-<YOUR_NAME>-lm-eval
   namespace: machine-learning
   labels:
-    app.kubernetes.io/instance: mlr-vllm-<YOUR_NAME>-lm-eval-fp8
+    app.kubernetes.io/instance: mlr-vllm-<YOUR_NAME>-lm-eval
 spec:
   backoffLimit: 0
   activeDeadlineSeconds: 86400
   template:
     metadata:
       labels:
-        app.kubernetes.io/instance: mlr-vllm-<YOUR_NAME>-lm-eval-fp8
+        app.kubernetes.io/instance: mlr-vllm-<YOUR_NAME>-lm-eval
     spec:
       restartPolicy: Never
       serviceAccountName: ml-workload
@@ -48,12 +44,10 @@ spec:
             set -e
 
             # ✎ Model to serve
-            MODEL_ID="RedHatAI/command-a-plus-05-2026-fp8"
-            # ✎ Parallelism — FP8: TP=4 DP=2, BF16: TP=8 DP=1
-            TP=4
-            DP=2
-
-            pip install -q cohere_melody>=0.9.0
+            MODEL_ID="Qwen/Qwen3-8B"
+            # ✎ Parallelism — adjust to model size
+            TP=1
+            DP=1
 
             export HF_HOME="/tier2/hf-hub"
             export HF_HUB_CACHE="/tier2/hf-hub"
@@ -87,15 +81,12 @@ spec:
                 --served-model-name "$MODEL_ID" \
                 --tensor-parallel-size ${TP} \
                 --data-parallel-size ${DP} \
-                --tool-call-parser cohere_command4 \
-                --reasoning-parser cohere_command4 \
-                --enable-auto-tool-choice \
                 --port 8000
         resources:
           requests:
-            nvidia.com/gpu: 8
+            nvidia.com/gpu: 1
           limits:
-            nvidia.com/gpu: 8
+            nvidia.com/gpu: 1
         env:
         - name: HF_TOKEN
           valueFrom:
@@ -132,8 +123,8 @@ spec:
             set -e
 
             # ✎ Benchmark configuration
-            MODEL="RedHatAI/command-a-plus-05-2026-fp8"
-            QUANTIZATION="fp8"
+            MODEL="Qwen/Qwen3-8B"
+            QUANTIZATION="bf16"
 
             apt-get update && apt-get install -y --no-install-recommends curl git
 
@@ -152,7 +143,7 @@ spec:
             echo "========================================================="
 
             # Install lm-eval from neuralmagic fork (has mmlu_pro_chat task)
-            pip install -q "lm_eval[api] @ git+https://github.com/neuralmagic/lm-evaluation-harness.git@mmlu-pro-chat-variant"
+            pip install -q "lm_eval[api] @ git+https://github.com/neuralmagic/lm-evaluation-harness.git@mmlu-pro-chat-variant" langdetect
 
             # Wait for the vLLM server to become healthy
             echo "[*] Waiting for vLLM server at ${SERVER_URL} ..."
@@ -186,8 +177,6 @@ spec:
                     'image': 'vllm/vllm-openai:v0.22.1',
                     'model': '${MODEL}',
                     'max_model_len': None,
-                    'tool_call_parser': 'cohere_command4',
-                    'reasoning_parser': 'cohere_command4',
                     'models_endpoint': json.loads('''${SERVER_MODELS}'''),
                 },
                 'client': {
@@ -207,7 +196,7 @@ spec:
                     'generation_kwargs': {
                         'temperature': 0.6,
                         'top_p': 0.95,
-                        'max_gen_toks': 65536,
+                        'max_gen_toks': 32768,
                     },
                 },
             }
@@ -218,8 +207,14 @@ spec:
 
             # ---- Benchmark sweep ----
             SEEDS=(0 1 2)
-            MODEL_ARGS="model=${MODEL},max_length=131072,base_url=http://localhost:8000/v1/chat/completions,num_concurrent=64,max_retries=3,tokenized_requests=False,tokenizer_backend=None,timeout=3600"
-            GEN_KWARGS_BASE="do_sample=True,temperature=0.6,top_p=0.95,max_gen_toks=65536"
+            MODEL_ARGS="model=${MODEL},max_length=32768,base_url=http://localhost:8000/v1/chat/completions,num_concurrent=64,max_retries=3,tokenized_requests=False,tokenizer_backend=None,timeout=3600"
+            GEN_KWARGS_BASE="do_sample=True,temperature=0.6,top_p=0.95,max_gen_toks=32768"
+
+            LIMIT_ARG=""
+            if [ -n "${LIMIT:-}" ]; then
+                echo "[*] Limiting to ${LIMIT} samples per task"
+                LIMIT_ARG="--limit ${LIMIT}"
+            fi
 
             # 0-shot tasks
             TASKS_0SHOT=("gsm8k_platinum_cot_llama" "mmlu_pro_chat" "ifeval")
@@ -236,7 +231,8 @@ spec:
                         --apply_chat_template \
                         --output_path "${RESULT_DIR}/${TASK}_seed${SEED}" \
                         --seed "$SEED" \
-                        --gen_kwargs "${GEN_KWARGS_BASE},seed=${SEED}"
+                        --gen_kwargs "${GEN_KWARGS_BASE},seed=${SEED}" \
+                        $LIMIT_ARG
                     echo "[+] Completed: ${TASK} (seed=${SEED})"
                 done
 
@@ -252,7 +248,8 @@ spec:
                     --fewshot_as_multiturn \
                     --output_path "${RESULT_DIR}/mmlu_cot_llama_seed${SEED}" \
                     --seed "$SEED" \
-                    --gen_kwargs "${GEN_KWARGS_BASE},seed=${SEED}"
+                    --gen_kwargs "${GEN_KWARGS_BASE},seed=${SEED}" \
+                    $LIMIT_ARG
                 echo "[+] Completed: mmlu_cot_llama (seed=${SEED})"
             done
 
@@ -309,7 +306,7 @@ spec:
               storageClassName: lvms-h100-tier1-storage
               resources:
                 requests:
-                  storage: 512Gi
+                  storage: 50Gi
       - name: tier2
         persistentVolumeClaim:
           claimName: mlr-tier2-<YOUR_NAME>


### PR DESCRIPTION
- Switch example model from Command A+ to Qwen/Qwen3-8B (1 GPU)
- Remove cohere_melody pip install and cohere_command4 parser flags
- Add langdetect to lm-eval pip install (ifeval crash fix)
- Add --limit support to lm-eval for quick validation runs
- Reduce tier1 storage from 512Gi to 50Gi for small model example