### PR TITLE
Add eval-agent skill to ai_skills/evaluation/

### DIFF
--- a/ai_skills/evaluation/eval-agent/README.md
+++ b/ai_skills/evaluation/eval-agent/README.md
@@ -1,0 +1,102 @@
+# eval-agent
+
+Unified LLM evaluation orchestrator for lm-eval and lighteval benchmarks, served via vLLM with GPU reservation via canhazgpu.
+
+## What it evaluates
+
+| Category | Tasks | Harness |
+|---|---|---|
+| instruct | GSM8k, MMLU, MMLU-Pro, IFEval, Math-500 | lm-eval + lighteval |
+| reasoning | GSM8k, MMLU-Pro, IFEval, Math-500, AIME25, GPQA Diamond | lm-eval + lighteval |
+| coding | LiveCodeBench v6 | lighteval |
+| long_context | MRCR | lm-eval |
+
+## Installation
+
+The skill is installed in the agent's workspace at runtime. No global installation needed.
+
+The agent (SKILL.md) handles all three venv setups during Step 0. See SKILL.md for the full setup script.
+
+**Requires in the workspace:**
+- `uv` — for creating venvs
+- `canhazgpu` (`chg`) — for GPU reservation
+- `hf` (Hugging Face CLI) — for downloading model configs
+
+**Python 3.12** is required for all three venvs.
+
+## Three-venv architecture
+
+| venv path | Contents | Use |
+|---|---|---|
+| `.venv/` | `eval-agent` package + `vllm` | CLI entry point + vLLM binary |
+| `.venvs/lm-eval/` | neuralmagic fork of lm-evaluation-harness | lm-eval tasks |
+| `.venvs/lighteval/` | neuralmagic eldar-fix-litellm branch of lighteval | lighteval tasks |
+
+Harnesses run via their absolute binary paths — venv activation is not needed.
+
+## CLI
+
+```
+eval-agent run     --model MODEL --server-cmd CMD --gen-params JSON --category CATEGORY \
+                   --max-length N --run-dir DIR \
+                   [--port N] [--num-concurrent N] [--timeout N] \
+                   [--lm-eval-venv PATH] [--lighteval-venv PATH] \
+                   [--health-timeout N] [--smoke-only]
+
+eval-agent resume  --run-dir DIR [--timeout N] [--num-concurrent N]
+eval-agent status  --run-dir DIR [--follow]
+eval-agent cleanup --run-dir DIR
+```
+
+## Run directory structure
+
+```
+runs/<run_name>/
+├── manifest.json          # Run config snapshot (immutable after creation)
+├── events.jsonl           # Chronological audit trail
+├── summary_data.json      # Machine-readable results (generated on completion)
+├── summary.md             # Human-readable summary (written by agent)
+├── commands.jsonl         # All harness commands actually executed
+├── logs/
+│   ├── vllm_server.log    # vLLM server output (KV-cache utilization here)
+│   ├── gsm8k_seed1234.log
+│   ├── math_500_seed1234.log
+│   └── ...
+├── configs/
+│   ├── litellm_math_500_seed1234.yaml   # Per (task, seed) lighteval config
+│   ├── litellm_aime25_seed1234.yaml
+│   └── ...
+└── results/
+    ├── gsm8k_seed1234.json              # lm-eval result (single JSON file)
+    ├── math_500_seed1234/               # lighteval result (directory)
+    │   └── details/results_*.json
+    └── ...
+```
+
+## Registry
+
+Task definitions are in `eval_agent/benchmarks/registry.yaml`. The registry is **immutable** — task names, harness, max_gen_tokens, n_repetitions, and metric fields must not be changed.
+
+Concurrency (`--num-concurrent`) is not in the registry. It is hardware-dependent and determined by the agent via smoke test KV-cache monitoring.
+
+## Monitoring KV-cache utilization
+
+vLLM logs GPU KV cache usage periodically:
+```
+GPU KV cache usage: 73.5%, CPU KV cache usage: 0.0%
+```
+
+Watch with:
+```bash
+tail -f runs/<run_name>/logs/vllm_server.log | grep "GPU KV cache"
+```
+
+If peak utilization exceeds 85%, halve `--num-concurrent` and resume. Values above 85% risk preemption, which collapses throughput.
+
+## Resuming interrupted runs
+
+```bash
+eval-agent resume --run-dir runs/<run_name>
+```
+
+The runner reads `events.jsonl` to identify completed `(task, seed)` pairs and skips them. A fresh vLLM server is started. Use `--num-concurrent` and `--timeout` to override manifest values.

--- a/ai_skills/evaluation/eval-agent/SKILL.md
+++ b/ai_skills/evaluation/eval-agent/SKILL.md
@@ -1,0 +1,301 @@
+---
+
+## name: eval-agent
+
+description: >-
+  Run the standard benchmark suite (lm-eval + lighteval tasks) against a model
+  served by vLLM, with GPU reservation via canhazgpu. Use when the user asks to
+  evaluate a model, run standard benchmarks, or measure model accuracy across the
+  full suite (GSM8k, MMLU, IFEval, Math-500, AIME25, GPQA Diamond, LiveCodeBench).
+  Handles GPU reservation, vLLM serving, benchmark execution, monitoring, retry,
+  and summary. Supports instruct, reasoning, coding, and long_context categories.
+
+# LLM Evaluation Agent
+
+Run the unified lm-eval + lighteval standard benchmark suite against a model served
+by vLLM. GPU reservation via canhazgpu. The CLI (`eval-agent`) handles deterministic
+execution; you handle planning, monitoring, retry, and summary.
+
+## Evaluation spec
+
+Tasks and their benchmark settings are defined in:
+`eval_agent/benchmarks/registry.yaml` (within the installed package, IMMUTABLE)
+
+**You may NOT change:** task names, harness, max_gen_tokens, n_repetitions, num_fewshot,
+apply_chat_template, fewshot_as_multiturn, task_str, metric.
+
+**You control:** vllm serve command, gen_params, num_concurrent, timeout, port.
+
+## ⚠️ MANDATORY FIRST STEP: Three-Venv Setup
+
+**STOP. Before doing anything else, set up all three venvs.**
+
+### Step 0: Setup and Validate Environment
+
+```bash
+# --- Base venv: router CLI + vllm ---
+if [ ! -d ./.venv ]; then
+    uv venv ./.venv --python 3.12
+    source ./.venv/bin/activate
+    SKILL_DIR=$(find ~/.claude/skills ~/.cursor/skills -name "eval-agent" -type d 2>/dev/null | head -1)
+    uv pip install -e "$SKILL_DIR"
+    uv pip install vllm
+else
+    source ./.venv/bin/activate
+fi
+
+# --- lm-eval venv ---
+if [ ! -d ./.venvs/lm-eval ]; then
+    uv venv ./.venvs/lm-eval --python 3.12
+    ./.venvs/lm-eval/bin/pip install \
+      "lm_eval[api,ifeval,multilingual] @ git+https://github.com/neuralmagic/lm-evaluation-harness.git@main"
+fi
+
+# --- lighteval venv ---
+if [ ! -d ./.venvs/lighteval ]; then
+    uv venv ./.venvs/lighteval --python 3.12
+    ./.venvs/lighteval/bin/pip install \
+      pillow "lighteval[extended] @ git+https://github.com/neuralmagic/lighteval.git@eldar-fix-litellm"
+fi
+
+# --- Validate ---
+eval-agent --help
+.venvs/lm-eval/bin/lm_eval --help
+.venvs/lighteval/bin/lighteval --help
+vllm --version
+```
+
+**If any validation command fails, STOP and fix the installation before proceeding.**
+
+## Workflow
+
+### Step 1: Gather information
+
+1. Verify all three venvs are set up (Step 0). If not, do Step 0 first.
+2. Get model ID from user. Optionally get `--max-gpus` limit.
+3. Download model configuration files:
+  ```bash
+   hf download <model_id> README.md config.json tokenizer_config.json generation_config.json \
+     --local-dir ./model-configs/<model_name>
+  ```
+   Read `README.md`, `config.json`, `tokenizer_config.json`, `generation_config.json`.
+4. Check for a vLLM recipe at `https://github.com/vllm-project/recipes`:
+  ```bash
+   curl -sL https://raw.githubusercontent.com/vllm-project/recipes/main/<Provider>/<ModelFamily>.md
+  ```
+   Use the Full-Featured server command from the recipe. Download any referenced chat template
+   files into the workspace.
+5. Determine model category:
+  - Chat template has thinking/reasoning tokens (`<think>`, `<|think|>`, etc.): **reasoning**
+  - Otherwise: **instruct**
+  - User requests long-context eval: **long_context**
+  - User requests coding eval: **coding**
+6. Run `chg status` to see free GPUs. Wait every 120s if not enough are available.
+
+### Step 2: Plan vLLM serving
+
+1. Check if model is quantized (look for `quantization_config` in config.json or filename like `-FP8`, `-GPTQ`).
+2. Estimate TP: use recipe value, or `ceil(1.5 × params × bytes_per_param / GPU_VRAM)`.
+3. Compute DP: `floor(available_gpus / TP)`.
+4. Determine `--max-model-len`:
+  - **instruct/reasoning/coding**: `max(task.max_gen_tokens for tasks in category) + 4096`
+    - instruct → 20480, reasoning → 69632, coding → 36864
+  - **long_context**: depends on whether YaRN scaling is applied:
+    - Ask the user: "Is YaRN (RoPE context extension) applied to this model?"
+    - **Without YaRN**: use `max_position_embeddings` from `config.json`
+    - **With YaRN**: read `rope_scaling` from `config.json`:
+      ```json
+      {"type": "yarn", "factor": 4.0, "original_max_position_embeddings": 32768}
+      ```
+      Effective max = `original_max_position_embeddings × factor`
+      (e.g. 32768 × 4.0 = 131072)
+    - If the model card or recipe specifies a different effective context, prefer that value.
+5. Build the full `vllm serve` command (all recipe flags preserved).
+6. Wrap with canhazgpu: `chg run --gpus <TP×DP> -- vllm serve ...`
+
+### Step 3: Build generation params
+
+Extract from `generation_config.json` or model card as a **JSON dict**:
+
+```json
+{"temperature": 0.6, "top_p": 0.95, "top_k": 20, "presence_penalty": 1.5}
+```
+
+**Do NOT include** `max_new_tokens`, `max_gen_toks`, or `seed` — the CLI injects these per task and per seed automatically.
+
+For greedy decoding (temperature=0 or not specified), pass `{}`.
+
+### Step 4a: Smoke test (MANDATORY — doubles as concurrency calibration)
+
+Choose an initial `--num-concurrent`:
+
+- instruct / coding: start at **64**
+- reasoning (long outputs): start at **32**
+
+```bash
+RUN_DIR="./runs/$(date +%Y%m%d_%H%M%S)_<model_short_name>_smoke"
+
+eval-agent run \
+  --model <model_name_as_served> \
+  --server-cmd "<full chg run ... -- vllm serve ... command>" \
+  --gen-params '{"temperature": 0.6, "top_p": 0.95}' \
+  --category <instruct|reasoning|coding|long_context> \
+  --port 8000 \
+  --max-length <max_model_len_from_step2> \
+  --num-concurrent <initial_value> \
+  --timeout 1200 \
+  --run-dir "$RUN_DIR" \
+  --smoke-only
+```
+
+The smoke test runs each task once (first seed, 100 samples each).
+
+**While the smoke test runs — monitor KV-cache utilization:**
+
+```bash
+# In a second terminal, tail the vLLM server log:
+tail -f $RUN_DIR/logs/vllm_server.log | grep "GPU KV cache"
+```
+
+vLLM logs lines like:
+
+```
+GPU KV cache usage: 73.5%, CPU KV cache usage: 0.0%
+```
+
+- **Peak > 85%**: KV-cache pressure — halve `--num-concurrent` and re-run smoke test.
+- **Peak ≤ 85%**: Proceed to full run with this concurrency.
+- Also watch for `Preempted` or `Aborted request` as secondary signals.
+
+**Do NOT proceed to the full run until all smoke tasks pass and concurrency is calibrated.**
+
+Common smoke failures:
+
+- Missing dependencies → reinstall the affected venv
+- Bad gen_params → check format, re-run smoke
+- Port conflict → change `--port`
+- OOM at server startup → increase TP or reduce `--max-model-len`
+
+### Step 4b: Full evaluation (only after smoke test passes)
+
+```bash
+RUN_DIR="./runs/$(date +%Y%m%d_%H%M%S)_<model_short_name>"
+
+eval-agent run \
+  --model <model_name_as_served> \
+  --server-cmd "<full chg run ... -- vllm serve ... command>" \
+  --gen-params '{"temperature": 0.6, "top_p": 0.95}' \
+  --category <instruct|reasoning|coding|long_context> \
+  --port 8000 \
+  --max-length <max_model_len_from_step2> \
+  --num-concurrent <calibrated_value> \
+  --timeout 1200 \
+  --run-dir "$RUN_DIR"
+```
+
+For reasoning models, consider `--timeout 3600`.
+
+### Step 5: Monitor (CRITICAL — active supervision required)
+
+**Do NOT wait passively.** Check every 30–60 seconds.
+
+```bash
+# In a second terminal, follow events:
+eval-agent status --follow --run-dir $RUN_DIR
+
+# In a third terminal, monitor KV-cache utilization:
+tail -f $RUN_DIR/logs/vllm_server.log | grep "GPU KV cache"
+```
+
+**KV-cache threshold during full run**: >85% peak utilization → preemption risk. Halve
+`--num-concurrent` and resume:
+
+```bash
+eval-agent resume --run-dir $RUN_DIR --num-concurrent <halved_value>
+```
+
+Also check `$RUN_DIR/events.jsonl` for `eval_failed` events. On any failure:
+
+1. Read the task log: `tail -50 $RUN_DIR/logs/<task>_seed<seed>.log`
+2. Identify root cause
+3. Fix and resume
+
+### Step 6: Handle failures
+
+Maximum 3 retry attempts per failure type.
+
+
+| Failure                   | Detection                                                         | Action                                                          |
+| ------------------------- | ----------------------------------------------------------------- | --------------------------------------------------------------- |
+| **OOM at server startup** | "CUDA out of memory" in `vllm_server.log`                         | Increase TP, reduce DP. Run `eval-agent cleanup` first.         |
+| **KV-cache preemption**   | GPU KV cache >85%, or `Preempted`/`Aborted` in vLLM log, HTTP 507 | Halve `--num-concurrent`. Resume.                               |
+| **Timeout**               | Requests timing out well under `--timeout`                        | Double `--timeout`. If still failing, halve `--num-concurrent`. |
+| **Bad gen params**        | SamplingParams mismatch in vLLM log                               | Fix `--gen-params`, re-run smoke.                               |
+| **Port conflict**         | "Address already in use"                                          | Change `--port`.                                                |
+
+
+**Never change task names, n_repetitions, or harness. Only adjust environment knobs.**
+
+### Step 7: Cleanup
+
+1. CLI kills vLLM automatically when run completes. `chg run` exits, freeing GPUs.
+2. Run `chg status` to confirm GPUs are free.
+3. If GPUs still reserved: `eval-agent cleanup --run-dir $RUN_DIR`, then check again.
+4. If still stuck: `ps aux | grep vllm` and kill orphan processes manually.
+
+### Step 8: Write summary
+
+1. Read `$RUN_DIR/summary_data.json` (generated by CLI on completion).
+2. Write `$RUN_DIR/summary.md` in plain English:
+  - Model name, category, key configuration (TP, DP, gen_params, num_concurrent)
+  - For each benchmark: mean score across seeds with context
+    - lm-eval tasks: averaged across 3 seeds
+    - lighteval tasks: averaged across 3 or 8 seeds (AIME25 uses 8)
+  - Timing stats, anomalies (e.g. first seed slower due to compilation)
+  - Failures with root cause analysis
+  - Cleanup confirmation
+3. Present key results to the user with brief interpretation.
+
+## Resuming Interrupted Runs
+
+```bash
+eval-agent resume --run-dir <path-to-interrupted-run>
+```
+
+Reads `events.jsonl` to find completed (task, seed) pairs and skips them.
+Starts a fresh vLLM server. Use `--timeout` and `--num-concurrent` to override.
+
+**Do not use resume if:** smoke test failed (fix and re-run smoke), wrong model/category
+(start fresh), or registry changed (start fresh).
+
+## CLI Reference
+
+```
+eval-agent run     --model M --server-cmd CMD --gen-params JSON --category C \
+                   --max-length L --run-dir D \
+                   [--port P] [--num-concurrent N] [--timeout T] \
+                   [--lm-eval-venv PATH] [--lighteval-venv PATH] \
+                   [--health-timeout H] [--smoke-only]
+
+eval-agent resume  --run-dir D [--timeout T] [--num-concurrent N] [--health-timeout H]
+eval-agent status  --run-dir D [--follow]
+eval-agent cleanup --run-dir D
+```
+
+## Verifying Sampling Parameters Reach vLLM
+
+Start vLLM with logging enabled and inspect the SamplingParams lines:
+
+```bash
+VLLM_LOGGING_LEVEL=INFO vllm serve <model> \
+    --enable-log-requests \
+    --uvicorn-log-level info
+```
+
+Look for lines like:
+
+```
+SamplingParams(n=1, presence_penalty=1.5, temperature=0.6, top_p=0.95, top_k=20, seed=1234, ...)
+```
+
+Confirm seed, temperature, and all sampling params are correct before the full run.

--- a/ai_skills/evaluation/eval-agent/eval_agent/audit.py
+++ b/ai_skills/evaluation/eval-agent/eval_agent/audit.py
@@ -1,0 +1,148 @@
+"""Structured audit trail for evaluation runs."""
+
+import json
+import time
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+
+class RunAudit:
+    """Manages the audit trail for a single evaluation run."""
+
+    EVENT_TYPES = frozenset({
+        "run_started",
+        "run_resumed",
+        "server_started",
+        "server_ready",
+        "smoke_passed",
+        "eval_started",
+        "eval_completed",
+        "eval_failed",
+        "eval_skipped",
+        "server_stopped",
+        "run_completed",
+        "resume_failed",
+    })
+
+    def __init__(self, run_dir: Path):
+        self.run_dir = Path(run_dir)
+        self.logs_dir = self.run_dir / "logs"
+        self.results_dir = self.run_dir / "results"
+        self.configs_dir = self.run_dir / "configs"
+        self._events_path = self.run_dir / "events.jsonl"
+        self._commands_path = self.run_dir / "commands.jsonl"
+        self._manifest_path = self.run_dir / "manifest.json"
+
+    def init_dirs(self) -> None:
+        self.run_dir.mkdir(parents=True, exist_ok=True)
+        self.logs_dir.mkdir(exist_ok=True)
+        self.results_dir.mkdir(exist_ok=True)
+        self.configs_dir.mkdir(exist_ok=True)
+
+    def write_manifest(
+        self,
+        *,
+        model: str,
+        category: str,
+        server_cmd: str,
+        base_gen_params: dict,
+        port: int,
+        num_concurrent: int,
+        timeout: int,
+        max_length: int,
+        smoke_only: bool,
+        lm_eval_venv: str,
+        lighteval_venv: str,
+        registry_snapshot: dict,
+    ) -> dict:
+        manifest = {
+            "run_id": uuid.uuid4().hex[:12],
+            "created_at": datetime.now(timezone.utc).isoformat(),
+            "model": model,
+            "category": category,
+            "server_cmd": server_cmd,
+            "base_gen_params": base_gen_params,
+            "port": port,
+            "num_concurrent": num_concurrent,
+            "timeout": timeout,
+            "max_length": max_length,
+            "smoke_only": smoke_only,
+            "lm_eval_venv": lm_eval_venv,
+            "lighteval_venv": lighteval_venv,
+            "seeds": registry_snapshot.get("seeds", []),
+            "benchmarks": [
+                {
+                    "name": t["name"],
+                    "harness": t["harness"],
+                    "n_repetitions": t["n_repetitions"],
+                    "max_gen_tokens": t["max_gen_tokens"],
+                }
+                for t in registry_snapshot.get("tasks", [])
+            ],
+        }
+        self._manifest_path.write_text(json.dumps(manifest, indent=2) + "\n")
+        return manifest
+
+    def load_manifest(self) -> Optional[dict]:
+        if self._manifest_path.exists():
+            return json.loads(self._manifest_path.read_text())
+        return None
+
+    def log_event(self, event_type: str, **data: Any) -> dict:
+        if event_type not in self.EVENT_TYPES:
+            raise ValueError(
+                f"Unknown event type {event_type!r}. "
+                f"Valid: {sorted(self.EVENT_TYPES)}"
+            )
+        event = {
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "elapsed_s": round(time.monotonic() - _PROCESS_START, 2),
+            "event": event_type,
+            **data,
+        }
+        with open(self._events_path, "a") as f:
+            f.write(json.dumps(event) + "\n")
+        return event
+
+    def log_command(self, cmd: str, *, description: str = "") -> dict:
+        entry = {
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "command": cmd,
+            "description": description,
+        }
+        with open(self._commands_path, "a") as f:
+            f.write(json.dumps(entry) + "\n")
+        return entry
+
+    def read_events(self) -> list[dict]:
+        if not self._events_path.exists():
+            return []
+        events = []
+        for line_num, line in enumerate(self._events_path.read_text().splitlines(), 1):
+            line = line.strip()
+            if line:
+                try:
+                    events.append(json.loads(line))
+                except json.JSONDecodeError as e:
+                    import sys
+                    print(f"WARNING: Skipping corrupted event at line {line_num}: {e}", file=sys.stderr)
+        return events
+
+    def server_log_path(self) -> Path:
+        return self.logs_dir / "vllm_server.log"
+
+    def task_log_path(self, task_name: str, seed: int) -> Path:
+        return self.logs_dir / f"{task_name}_seed{seed}.log"
+
+    def task_lm_eval_result_path(self, task_name: str, seed: int) -> Path:
+        """JSON output file for lm-eval (--output_path target)."""
+        return self.results_dir / f"{task_name}_seed{seed}.json"
+
+    def task_lighteval_result_dir(self, task_name: str, seed: int) -> Path:
+        """Output directory for lighteval (--output-dir target)."""
+        return self.results_dir / f"{task_name}_seed{seed}"
+
+
+_PROCESS_START = time.monotonic()

--- a/ai_skills/evaluation/eval-agent/eval_agent/benchmarks/registry.yaml
+++ b/ai_skills/evaluation/eval-agent/eval_agent/benchmarks/registry.yaml
@@ -1,0 +1,139 @@
+# Benchmark registry -- IMMUTABLE
+# Do NOT change: task names, harness, max_gen_tokens, n_repetitions, num_fewshot,
+#                apply_chat_template, fewshot_as_multiturn, task_str, metric.
+# Only environment knobs are adjustable: timeout, num_concurrent, port, gen_params.
+#
+# max_gen_tokens: the benchmark standard for this task.
+# Runner computes: effective_max_gen_tokens = min(task.max_gen_tokens, max_model_len - 4096)
+#
+# num_concurrent is NOT here — it depends on model+hardware, not the benchmark.
+# The agent sets it via --num-concurrent after observing smoke test KV-cache utilization.
+#
+# 8 seeds to cover AIME25 (8 repetitions); 3-rep tasks use seeds[0:3].
+seeds: [1234, 2345, 3456, 4567, 5678, 6789, 7890, 8901]
+
+categories:
+  instruct:
+    # Recommended max_model_len = max(max_gen_tokens) + 4096 = 16384 + 4096 = 20480
+    tasks:
+      - name: gsm8k_platinum_cot_llama
+        harness: lm-eval
+        max_gen_tokens: 8192
+        n_repetitions: 3
+        num_fewshot: 5
+        apply_chat_template: true
+        fewshot_as_multiturn: true
+        metric: "exact_match,strict-match"
+
+      - name: mmlu_cot_llama
+        harness: lm-eval
+        max_gen_tokens: 8192
+        n_repetitions: 3
+        num_fewshot: 5
+        apply_chat_template: true
+        fewshot_as_multiturn: true
+        metric: "exact_match,strict_match"
+
+      - name: mmlu_pro_chat
+        harness: lm-eval
+        max_gen_tokens: 8192
+        n_repetitions: 3
+        num_fewshot: 5
+        apply_chat_template: true
+        fewshot_as_multiturn: true
+        metric: "exact_match,custom-extract"
+
+      - name: ifeval
+        harness: lm-eval
+        max_gen_tokens: 8192
+        n_repetitions: 3
+        num_fewshot: 0
+        apply_chat_template: true
+        fewshot_as_multiturn: false
+        metric: "inst_level_strict_acc,none"
+
+      - name: math_500
+        harness: lighteval
+        task_str: "math_500|0"
+        max_gen_tokens: 16384
+        n_repetitions: 3
+        num_fewshot: 0
+        metric: "pass@k:k=1&n=1"
+
+  reasoning:
+    # Recommended max_model_len = max(32000, 65536) + 4096 = 69632
+    tasks:
+      - name: gsm8k_platinum_cot_llama
+        harness: lm-eval
+        max_gen_tokens: 32000
+        n_repetitions: 3
+        num_fewshot: 0
+        apply_chat_template: true
+        fewshot_as_multiturn: false
+        metric: "exact_match,strict-match"
+
+      - name: mmlu_pro_chat
+        harness: lm-eval
+        max_gen_tokens: 32000
+        n_repetitions: 3
+        num_fewshot: 0
+        apply_chat_template: true
+        fewshot_as_multiturn: false
+        metric: "exact_match,custom-extract"
+
+      - name: ifeval
+        harness: lm-eval
+        max_gen_tokens: 32000
+        n_repetitions: 3
+        num_fewshot: 0
+        apply_chat_template: true
+        fewshot_as_multiturn: false
+        metric: "inst_level_strict_acc,none"
+
+      - name: math_500
+        harness: lighteval
+        task_str: "math_500|0"
+        max_gen_tokens: 65536
+        n_repetitions: 3
+        num_fewshot: 0
+        metric: "pass@k:k=1&n=1"
+
+      - name: aime25
+        harness: lighteval
+        task_str: "aime25|0"
+        max_gen_tokens: 65536
+        n_repetitions: 8
+        num_fewshot: 0
+        metric: "pass@k:k=1&n=1"
+
+      - name: gpqa_diamond
+        harness: lighteval
+        task_str: "gpqa:diamond|0"
+        max_gen_tokens: 65536
+        n_repetitions: 3
+        num_fewshot: 0
+        metric: "gpqa_pass@k:k=1&n=1"
+
+  coding:
+    # Recommended max_model_len = 32768 + 4096 = 36864
+    tasks:
+      - name: lcb_codegeneration_v6
+        harness: lighteval
+        task_str: "lcb:codegeneration_v6|0"
+        max_gen_tokens: 32768
+        n_repetitions: 3
+        num_fewshot: 0
+        metric: "codegen_pass@k:k=1&n=1"
+
+  long_context:
+    # max_model_len = model's native max_position_embeddings from config.json
+    # The 4096-token buffer rule does NOT apply here.
+    tasks:
+      - name: mrcr
+        harness: lm-eval
+        max_gen_tokens: 8192
+        n_repetitions: 3
+        num_fewshot: 0
+        apply_chat_template: true
+        fewshot_as_multiturn: false
+        metric: "auc"

--- a/ai_skills/evaluation/eval-agent/eval_agent/cli.py
+++ b/ai_skills/evaluation/eval-agent/eval_agent/cli.py
@@ -1,0 +1,331 @@
+"""eval-agent CLI: run | resume | status | cleanup"""
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+
+from eval_agent.audit import RunAudit
+from eval_agent.runner import BenchmarkRunner, get_tasks_for_category, load_registry
+from eval_agent.server import VLLMServer, ServerError
+from eval_agent.summary import generate_summary_data
+
+
+def _write_summary_data(run_dir: Path) -> None:
+    print("\nGenerating summary data...", file=sys.stderr)
+    summary = generate_summary_data(run_dir)
+    out = run_dir / "summary_data.json"
+    out.write_text(json.dumps(summary, indent=2))
+    print(f"Summary data: {out}", file=sys.stderr)
+    print("Agent should write summary.md from this data.", file=sys.stderr)
+
+
+def cmd_run(args: argparse.Namespace) -> int:
+    run_dir = Path(args.run_dir)
+    audit = RunAudit(run_dir)
+
+    # Parse gen_params
+    try:
+        base_gen_params = json.loads(args.gen_params) if args.gen_params else {}
+    except json.JSONDecodeError as e:
+        print(f"ERROR: --gen-params is not valid JSON: {e}", file=sys.stderr)
+        return 1
+
+    registry = load_registry()
+    tasks = get_tasks_for_category(args.category)
+
+    # Validate max_length: must fit at least the smallest task + 4096 prompt buffer
+    # (long_context is exempt — agent sizes max_length to model's native max)
+    if args.category != "long_context":
+        min_needed = min(t["max_gen_tokens"] for t in tasks) + 4096
+        if args.max_length < min_needed:
+            print(
+                f"ERROR: --max-length {args.max_length} is too small for {args.category}. "
+                f"Minimum needed: {min_needed}",
+                file=sys.stderr,
+            )
+            return 1
+
+    # Validate venv binaries exist
+    from pathlib import Path as _P
+    lm_eval_bin = _P(args.lm_eval_venv) / "bin" / "lm_eval"
+    lighteval_bin = _P(args.lighteval_venv) / "bin" / "lighteval"
+    has_lm_eval = any(t["harness"] == "lm-eval" for t in tasks)
+    has_lighteval = any(t["harness"] == "lighteval" for t in tasks)
+    if has_lm_eval and not lm_eval_bin.exists():
+        print(f"ERROR: lm-eval binary not found: {lm_eval_bin}", file=sys.stderr)
+        print("Install with: .venvs/lm-eval/bin/pip install lm_eval[api,ifeval,multilingual]", file=sys.stderr)
+        return 1
+    if has_lighteval and not lighteval_bin.exists():
+        print(f"ERROR: lighteval binary not found: {lighteval_bin}", file=sys.stderr)
+        print("Install with: .venvs/lighteval/bin/pip install lighteval[extended]", file=sys.stderr)
+        return 1
+
+    audit.init_dirs()
+    manifest = audit.write_manifest(
+        model=args.model,
+        category=args.category,
+        server_cmd=args.server_cmd,
+        base_gen_params=base_gen_params,
+        port=args.port,
+        num_concurrent=args.num_concurrent,
+        timeout=args.timeout,
+        max_length=args.max_length,
+        smoke_only=args.smoke_only,
+        lm_eval_venv=args.lm_eval_venv,
+        lighteval_venv=args.lighteval_venv,
+        registry_snapshot={"seeds": registry["seeds"], "tasks": tasks},
+    )
+    audit.log_event("run_started", run_id=manifest["run_id"], model=args.model)
+
+    server = VLLMServer(
+        server_cmd=args.server_cmd,
+        audit=audit,
+        port=args.port,
+        health_timeout=args.health_timeout,
+    )
+    try:
+        server.start()
+    except ServerError as e:
+        print(f"ERROR: {e}", file=sys.stderr)
+        audit.log_event("run_completed", status="server_failed", error=str(e))
+        return 1
+
+    try:
+        runner = BenchmarkRunner(
+            audit=audit,
+            model=args.model,
+            category=args.category,
+            base_gen_params=base_gen_params,
+            port=args.port,
+            num_concurrent=args.num_concurrent,
+            timeout=args.timeout,
+            max_length=args.max_length,
+            lm_eval_venv=args.lm_eval_venv,
+            lighteval_venv=args.lighteval_venv,
+            smoke_only=args.smoke_only,
+        )
+        results = runner.run_all()
+    finally:
+        server.stop()
+
+    status = "completed" if not results["failed"] else "completed_with_failures"
+    audit.log_event(
+        "run_completed",
+        status=status,
+        completed=len(results["completed"]),
+        failed=len(results["failed"]),
+        failures=results["failed"],
+    )
+    print(json.dumps(results, indent=2))
+    _write_summary_data(run_dir)
+    return 0 if not results["failed"] else 1
+
+
+def cmd_status(args: argparse.Namespace) -> int:
+    run_dir = Path(args.run_dir)
+    audit = RunAudit(run_dir)
+
+    manifest = audit.load_manifest()
+    if manifest is None:
+        print(f"No run found in {run_dir}", file=sys.stderr)
+        return 1
+
+    events = audit.read_events()
+    print(f"Run ID:   {manifest['run_id']}")
+    print(f"Model:    {manifest['model']}")
+    print(f"Category: {manifest['category']}")
+    print(f"Events:   {len(events)}")
+
+    if events:
+        last = events[-1]
+        print(f"Last event: {last['event']} at {last['timestamp']}")
+
+    completed = [e for e in events if e["event"] == "eval_completed"]
+    failed = [e for e in events if e["event"] == "eval_failed"]
+    print(f"Evals completed: {len(completed)}, failed: {len(failed)}")
+
+    if args.follow:
+        _follow_events(audit)
+
+    return 0
+
+
+def _follow_events(audit: RunAudit) -> None:
+    seen = len(audit.read_events())
+    try:
+        while True:
+            events = audit.read_events()
+            for event in events[seen:]:
+                ts = event.get("timestamp", "")
+                payload = {k: v for k, v in event.items() if k not in ("timestamp", "elapsed_s", "event")}
+                print(f"[{ts}] {event['event']}: {json.dumps(payload)}")
+            seen = len(events)
+            if any(e["event"] == "run_completed" for e in events):
+                break
+            time.sleep(2)
+    except KeyboardInterrupt:
+        pass
+
+
+def cmd_resume(args: argparse.Namespace) -> int:
+    run_dir = Path(args.run_dir)
+    audit = RunAudit(run_dir)
+
+    manifest = audit.load_manifest()
+    if manifest is None:
+        print(f"ERROR: No run found in {run_dir}", file=sys.stderr)
+        return 1
+
+    events = audit.read_events()
+    completed = [(e["task"], e["seed"]) for e in events if e["event"] == "eval_completed"]
+    failed = [(e["task"], e["seed"]) for e in events if e["event"] == "eval_failed"]
+
+    print(f"Resuming run: {manifest['run_id']}")
+    print(f"Model: {manifest['model']}, Category: {manifest['category']}")
+    print(f"Already completed: {len(completed)} evaluations")
+    if completed:
+        for task, seed in sorted(completed):
+            print(f"  Skipping: {task} seed={seed}")
+    print(f"Previously failed: {len(failed)} evaluations (will retry)")
+
+    timeout = args.timeout if args.timeout else manifest["timeout"]
+    num_concurrent = args.num_concurrent if args.num_concurrent else manifest["num_concurrent"]
+
+    server = VLLMServer(
+        server_cmd=manifest["server_cmd"],
+        audit=audit,
+        port=manifest["port"],
+        health_timeout=args.health_timeout,
+    )
+    try:
+        server.start()
+    except ServerError as e:
+        print(f"ERROR: {e}", file=sys.stderr)
+        audit.log_event("resume_failed", error=str(e))
+        return 1
+
+    try:
+        audit.log_event("run_resumed", run_id=manifest["run_id"])
+        runner = BenchmarkRunner(
+            audit=audit,
+            model=manifest["model"],
+            category=manifest["category"],
+            base_gen_params=manifest["base_gen_params"],
+            port=manifest["port"],
+            num_concurrent=num_concurrent,
+            timeout=timeout,
+            max_length=manifest["max_length"],
+            lm_eval_venv=manifest["lm_eval_venv"],
+            lighteval_venv=manifest["lighteval_venv"],
+            smoke_only=False,
+            skip_completed=True,
+        )
+        results = runner.run_all()
+    finally:
+        server.stop()
+
+    status = "completed" if not results["failed"] else "completed_with_failures"
+    audit.log_event(
+        "run_completed",
+        status=status,
+        completed=len(results["completed"]),
+        failed=len(results["failed"]),
+        skipped=len(results.get("skipped", [])),
+        failures=results["failed"],
+    )
+    print(json.dumps(results, indent=2))
+    _write_summary_data(run_dir)
+    return 0 if not results["failed"] else 1
+
+
+def cmd_cleanup(args: argparse.Namespace) -> int:
+    run_dir = Path(args.run_dir)
+    audit = RunAudit(run_dir)
+    events = audit.read_events()
+
+    server_started = [e for e in events if e["event"] == "server_started"]
+    server_stopped = [e for e in events if e["event"] == "server_stopped"]
+
+    if len(server_stopped) >= len(server_started):
+        print("Server already stopped.")
+        return 0
+
+    last_start = server_started[-1] if server_started else None
+    pid = last_start.get("pid") if last_start else None
+
+    if pid:
+        import os
+        import signal
+        try:
+            pgid = os.getpgid(pid)
+            os.killpg(pgid, signal.SIGTERM)
+            print(f"Sent SIGTERM to process group {pgid}")
+        except (ProcessLookupError, OSError) as e:
+            print(f"Process {pid} not found: {e}")
+
+    audit.log_event("server_stopped", pid=pid, reason="manual_cleanup")
+    print("Cleanup done. Run `chg status` to verify GPUs are free.")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="eval-agent",
+        description="Unified LLM evaluation orchestrator (lm-eval + lighteval)",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    # --- run ---
+    p_run = sub.add_parser("run", help="Execute evaluation benchmarks")
+    p_run.add_argument("--model", required=True)
+    p_run.add_argument("--server-cmd", required=True)
+    p_run.add_argument("--gen-params", default="{}",
+                       help="JSON dict of generation params (no seed, no max tokens)")
+    p_run.add_argument("--category", required=True,
+                       choices=["instruct", "reasoning", "coding", "long_context"])
+    p_run.add_argument("--port", type=int, default=8000)
+    p_run.add_argument("--max-length", type=int, required=True,
+                       help="vLLM --max-model-len used in server-cmd")
+    p_run.add_argument("--num-concurrent", type=int, default=64,
+                       help="Concurrent requests for both harnesses")
+    p_run.add_argument("--timeout", type=int, default=1200,
+                       help="Per-request timeout in seconds")
+    p_run.add_argument("--lm-eval-venv", default=".venvs/lm-eval",
+                       help="Path to the lm-eval venv")
+    p_run.add_argument("--lighteval-venv", default=".venvs/lighteval",
+                       help="Path to the lighteval venv")
+    p_run.add_argument("--health-timeout", type=int, default=600)
+    p_run.add_argument("--smoke-only", action="store_true",
+                       help="Run each task once with 100 samples (first seed only)")
+    p_run.add_argument("--run-dir", required=True)
+
+    # --- status ---
+    p_status = sub.add_parser("status", help="Show run status")
+    p_status.add_argument("--run-dir", required=True)
+    p_status.add_argument("--follow", action="store_true")
+
+    # --- resume ---
+    p_resume = sub.add_parser("resume", help="Resume an interrupted run")
+    p_resume.add_argument("--run-dir", required=True)
+    p_resume.add_argument("--health-timeout", type=int, default=600)
+    p_resume.add_argument("--timeout", type=int, help="Override timeout from manifest")
+    p_resume.add_argument("--num-concurrent", type=int, help="Override concurrency from manifest")
+
+    # --- cleanup ---
+    p_cleanup = sub.add_parser("cleanup", help="Kill orphan server processes")
+    p_cleanup.add_argument("--run-dir", required=True)
+
+    return parser
+
+
+def main() -> None:
+    parser = build_parser()
+    args = parser.parse_args()
+    handlers = {"run": cmd_run, "resume": cmd_resume, "status": cmd_status, "cleanup": cmd_cleanup}
+    sys.exit(handlers[args.command](args))
+
+
+if __name__ == "__main__":
+    main()

--- a/ai_skills/evaluation/eval-agent/eval_agent/lighteval_runner.py
+++ b/ai_skills/evaluation/eval-agent/eval_agent/lighteval_runner.py
@@ -1,0 +1,66 @@
+"""lighteval harness command builder.
+
+Builds lighteval invocations using the harness binary from the dedicated
+lighteval venv (.venvs/lighteval/bin/lighteval). Writes a per-(task, seed)
+litellm_config.yaml into <run_dir>/configs/ and points lighteval at it.
+"""
+
+import shlex
+from pathlib import Path
+from typing import Optional
+
+import yaml
+
+
+def build_litellm_config(
+    *,
+    model: str,
+    port: int,
+    timeout: int,
+    num_concurrent: int,
+    gen_params: dict,
+    seed: int,
+    max_new_tokens: int,
+) -> dict:
+    """Build the litellm_config.yaml content dict for one (task, seed) run."""
+    generation_parameters = {**gen_params, "seed": seed, "max_new_tokens": max_new_tokens}
+    return {
+        "model_parameters": {
+            "provider": "hosted_vllm",
+            "model_name": f"hosted_vllm/{model}",
+            "base_url": f"http://127.0.0.1:{port}/v1",
+            "api_key": "",
+            "timeout": timeout,
+            "concurrent_requests": num_concurrent,
+            "generation_parameters": generation_parameters,
+        }
+    }
+
+
+def write_litellm_config(config: dict, config_path: Path) -> None:
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(config_path, "w") as f:
+        yaml.dump(config, f, default_flow_style=False, allow_unicode=True)
+
+
+def build_lighteval_command(
+    *,
+    task: dict,
+    config_path: str,
+    output_dir: str,
+    lighteval_bin: str,
+    max_samples: Optional[int] = None,
+) -> str:
+    """Build a single lighteval invocation string."""
+    parts = [
+        lighteval_bin,
+        "endpoint",
+        "litellm",
+        config_path,
+        shlex.quote(task["task_str"]),
+        "--output-dir", output_dir,
+        "--save-details",
+    ]
+    if max_samples is not None:
+        parts.extend(["--max-samples", str(max_samples)])
+    return " ".join(parts)

--- a/ai_skills/evaluation/eval-agent/eval_agent/lm_eval_runner.py
+++ b/ai_skills/evaluation/eval-agent/eval_agent/lm_eval_runner.py
@@ -1,0 +1,84 @@
+"""lm-eval harness command builder.
+
+Builds lm_eval invocations using the harness binary from the dedicated
+lm-eval venv (.venvs/lm-eval/bin/lm_eval). Generation params are
+received as a dict and converted to the lm-eval gen_kwargs string format.
+"""
+
+import shlex
+from pathlib import Path
+from typing import Optional
+
+
+def gen_params_to_lm_eval_kwargs(params: dict, seed: int, max_gen_toks: int) -> str:
+    """Convert JSON gen params dict to lm-eval --gen_kwargs string.
+
+    Adds do_sample=True when any non-zero sampling param is present.
+    Always injects seed and max_gen_toks.
+    """
+    has_sampling = any(
+        k in params and params[k] not in (0, 0.0, False)
+        for k in ("temperature", "top_p", "top_k")
+    )
+    parts = []
+    if has_sampling:
+        parts.append("do_sample=True")
+    for k, v in params.items():
+        parts.append(f"{k}={v}")
+    parts.append(f"seed={seed}")
+    parts.append(f"max_gen_toks={max_gen_toks}")
+    return ",".join(parts)
+
+
+def build_lm_eval_command(
+    *,
+    task: dict,
+    model: str,
+    seed: int,
+    gen_params: dict,
+    effective_max_gen_tokens: int,
+    port: int,
+    num_concurrent: int,
+    timeout: int,
+    max_length: int,
+    output_path: str,
+    lm_eval_bin: str,
+    limit: Optional[int] = None,
+) -> str:
+    """Build a single lm_eval invocation string."""
+    base_url = f"http://127.0.0.1:{port}/v1/chat/completions"
+
+    model_args = (
+        f"model={model},"
+        f"max_length={max_length},"
+        f"base_url={base_url},"
+        f"num_concurrent={num_concurrent},"
+        f"max_retries=3,"
+        f"tokenized_requests=False,"
+        f"tokenizer_backend=None,"
+        f"timeout={timeout}"
+    )
+
+    gen_kwargs = gen_params_to_lm_eval_kwargs(gen_params, seed, effective_max_gen_tokens)
+
+    parts = [
+        lm_eval_bin,
+        "--model", "local-chat-completions",
+        "--tasks", task["name"],
+        "--model_args", shlex.quote(model_args),
+        "--num_fewshot", str(task["num_fewshot"]),
+        "--output_path", shlex.quote(output_path),
+        "--seed", str(seed),
+        "--gen_kwargs", shlex.quote(gen_kwargs),
+    ]
+
+    if task.get("apply_chat_template", False):
+        parts.append("--apply_chat_template")
+
+    if task.get("fewshot_as_multiturn", False):
+        parts.append("--fewshot_as_multiturn")
+
+    if limit is not None:
+        parts.extend(["--limit", str(limit)])
+
+    return " ".join(parts)

--- a/ai_skills/evaluation/eval-agent/eval_agent/runner.py
+++ b/ai_skills/evaluation/eval-agent/eval_agent/runner.py
@@ -1,0 +1,221 @@
+"""Unified benchmark runner.
+
+Loads the registry, iterates tasks × seeds, and routes each evaluation
+to the appropriate harness (lm-eval or lighteval) via explicit venv binary paths.
+"""
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Optional
+
+import yaml
+
+from eval_agent.audit import RunAudit
+from eval_agent.lm_eval_runner import build_lm_eval_command
+from eval_agent.lighteval_runner import (
+    build_litellm_config,
+    write_litellm_config,
+    build_lighteval_command,
+)
+
+_REGISTRY_PATH = Path(__file__).parent / "benchmarks" / "registry.yaml"
+_SMOKE_SAMPLES = 100
+
+
+def load_registry() -> dict:
+    with open(_REGISTRY_PATH) as f:
+        return yaml.safe_load(f)
+
+
+def get_tasks_for_category(category: str) -> list[dict]:
+    registry = load_registry()
+    cat = registry.get("categories", {}).get(category)
+    if cat is None:
+        valid = list(registry.get("categories", {}).keys())
+        raise ValueError(f"Unknown category {category!r}. Valid: {valid}")
+    return cat["tasks"]
+
+
+def get_seeds() -> list[int]:
+    return load_registry().get("seeds", [1234, 2345, 3456, 4567, 5678, 6789, 7890, 8901])
+
+
+def compute_recommended_max_model_len(category: str) -> int:
+    """Return max(task.max_gen_tokens) + 4096 for the given category.
+
+    For long_context the agent must supply the model's native max length
+    from config.json — this function is not meaningful there.
+    """
+    tasks = get_tasks_for_category(category)
+    return max(t["max_gen_tokens"] for t in tasks) + 4096
+
+
+class BenchmarkRunner:
+    """Runs the full benchmark suite for a given category."""
+
+    def __init__(
+        self,
+        *,
+        audit: RunAudit,
+        model: str,
+        category: str,
+        base_gen_params: dict,
+        port: int = 8000,
+        num_concurrent: int = 64,
+        timeout: int = 1200,
+        max_length: int,
+        lm_eval_venv: str,
+        lighteval_venv: str,
+        smoke_only: bool = False,
+        skip_completed: bool = False,
+    ):
+        self.audit = audit
+        self.model = model
+        self.category = category
+        self.base_gen_params = base_gen_params
+        self.port = port
+        self.num_concurrent = num_concurrent
+        self.timeout = timeout
+        self.max_length = max_length
+        self.lm_eval_bin = str(Path(lm_eval_venv) / "bin" / "lm_eval")
+        self.lighteval_bin = str(Path(lighteval_venv) / "bin" / "lighteval")
+        self.smoke_only = smoke_only
+        self.skip_completed = skip_completed
+        self.tasks = get_tasks_for_category(category)
+        self.seeds = get_seeds()
+
+        self.completed_work: set[tuple[str, int]] = set()
+        if skip_completed:
+            for e in audit.read_events():
+                if e["event"] == "eval_completed":
+                    self.completed_work.add((e["task"], e["seed"]))
+
+    def run_all(self) -> dict:
+        results: dict = {"completed": [], "failed": [], "skipped": []}
+
+        if self.smoke_only:
+            return self._run_smoke(results)
+
+        for task in self.tasks:
+            task_seeds = self.seeds[: task["n_repetitions"]]
+            for seed in task_seeds:
+                task_name = task["name"]
+                if (task_name, seed) in self.completed_work:
+                    results["skipped"].append({"task": task_name, "seed": seed})
+                    self.audit.log_event(
+                        "eval_skipped", task=task_name, seed=seed, reason="already_completed"
+                    )
+                    continue
+
+                success = self._run_single(task, seed)
+                entry = {"task": task_name, "seed": seed}
+                (results["completed"] if success else results["failed"]).append(entry)
+
+        return results
+
+    def _run_smoke(self, results: dict) -> dict:
+        """Run each task once (first seed, --max-samples / --limit 100)."""
+        seed = self.seeds[0]
+        for task in self.tasks:
+            success = self._run_single(task, seed, limit=_SMOKE_SAMPLES)
+            entry = {"task": task["name"], "seed": seed, "smoke": True}
+            (results["completed"] if success else results["failed"]).append(entry)
+
+        if not results["failed"]:
+            self.audit.log_event("smoke_passed", tasks=[t["name"] for t in self.tasks])
+
+        return results
+
+    def _effective_max_gen(self, task: dict) -> int:
+        """Cap task's max_gen_tokens by the server's max_length minus prompt buffer."""
+        return min(task["max_gen_tokens"], self.max_length - 4096)
+
+    def _run_single(self, task: dict, seed: int, limit: Optional[int] = None) -> bool:
+        """Dispatch to the correct harness runner. Returns True on success."""
+        if task["harness"] == "lm-eval":
+            return self._run_lm_eval(task, seed, limit)
+        else:
+            return self._run_lighteval(task, seed, limit)
+
+    def _run_lm_eval(self, task: dict, seed: int, limit: Optional[int]) -> bool:
+        output_path = str(self.audit.task_lm_eval_result_path(task["name"], seed))
+        log_path = self.audit.task_log_path(task["name"], seed)
+        effective_max_gen = self._effective_max_gen(task)
+
+        cmd = build_lm_eval_command(
+            task=task,
+            model=self.model,
+            seed=seed,
+            gen_params=self.base_gen_params,
+            effective_max_gen_tokens=effective_max_gen,
+            port=self.port,
+            num_concurrent=self.num_concurrent,
+            timeout=self.timeout,
+            max_length=self.max_length,
+            output_path=output_path,
+            lm_eval_bin=self.lm_eval_bin,
+            limit=limit,
+        )
+        return self._execute(cmd, task["name"], seed, log_path)
+
+    def _clear_lighteval_caches(self) -> None:
+        # litellm creates .litellm_cache/ in the CWD between runs; stale entries
+        # cause different seeds to receive identical (cached) responses.
+        litellm_cache = Path(".litellm_cache")
+        if litellm_cache.exists():
+            shutil.rmtree(litellm_cache, ignore_errors=True)
+
+        # lighteval caches evaluation results under $HF_HOME/lighteval
+        hf_home = Path(os.environ.get("HF_HOME", Path.home() / ".cache" / "huggingface"))
+        lighteval_cache = hf_home / "lighteval"
+        if lighteval_cache.exists():
+            shutil.rmtree(lighteval_cache, ignore_errors=True)
+
+    def _run_lighteval(self, task: dict, seed: int, limit: Optional[int]) -> bool:
+        self._clear_lighteval_caches()
+        config_path = self.audit.configs_dir / f"litellm_{task['name']}_seed{seed}.yaml"
+        output_dir = str(self.audit.task_lighteval_result_dir(task["name"], seed))
+        effective_max_gen = self._effective_max_gen(task)
+        log_path = self.audit.task_log_path(task["name"], seed)
+
+        config = build_litellm_config(
+            model=self.model,
+            port=self.port,
+            timeout=self.timeout,
+            num_concurrent=self.num_concurrent,
+            gen_params=self.base_gen_params,
+            seed=seed,
+            max_new_tokens=effective_max_gen,
+        )
+        write_litellm_config(config, config_path)
+
+        cmd = build_lighteval_command(
+            task=task,
+            config_path=str(config_path),
+            output_dir=output_dir,
+            lighteval_bin=self.lighteval_bin,
+            max_samples=limit,
+        )
+        return self._execute(cmd, task["name"], seed, log_path)
+
+    def _execute(self, cmd: str, task_name: str, seed: int, log_path: Path) -> bool:
+        self.audit.log_command(cmd, description=f"{task_name} seed={seed}")
+        self.audit.log_event("eval_started", task=task_name, seed=seed)
+
+        with open(log_path, "w") as log_f:
+            proc = subprocess.run(cmd, shell=True, stdout=log_f, stderr=subprocess.STDOUT)
+
+        if proc.returncode == 0:
+            self.audit.log_event("eval_completed", task=task_name, seed=seed, returncode=0)
+            return True
+        else:
+            self.audit.log_event(
+                "eval_failed",
+                task=task_name,
+                seed=seed,
+                returncode=proc.returncode,
+                log=str(log_path),
+            )
+            return False

--- a/ai_skills/evaluation/eval-agent/eval_agent/server.py
+++ b/ai_skills/evaluation/eval-agent/eval_agent/server.py
@@ -1,0 +1,123 @@
+"""vLLM server process manager.
+
+Accepts a complete command string (typically `chg run --gpus N -- vllm serve ...`),
+starts it as a subprocess, polls the health endpoint, captures logs, and provides
+clean teardown.
+"""
+
+import os
+import signal
+import subprocess
+import time
+from pathlib import Path
+from typing import Optional
+
+import psutil
+import requests
+
+from eval_agent.audit import RunAudit
+
+
+class ServerError(Exception):
+    """Raised when the server fails to start or respond."""
+
+
+class VLLMServer:
+    """Manages a vLLM server process lifecycle."""
+
+    HEALTH_CHECK_TIMEOUT = 5
+    SIGTERM_WAIT = 15
+    SIGKILL_WAIT = 5
+
+    def __init__(
+        self,
+        server_cmd: str,
+        audit: RunAudit,
+        port: int = 8000,
+        health_timeout: int = 600,
+        health_interval: int = 5,
+    ):
+        self.server_cmd = server_cmd
+        self.audit = audit
+        self.port = port
+        self.health_timeout = health_timeout
+        self.health_interval = health_interval
+        self._process: Optional[subprocess.Popen] = None
+        self._log_file = None
+
+    @property
+    def base_url(self) -> str:
+        return f"http://127.0.0.1:{self.port}"
+
+    @property
+    def pid(self) -> Optional[int]:
+        return self._process.pid if self._process else None
+
+    def start(self) -> None:
+        """Start the server process and wait for it to become healthy."""
+        log_path = self.audit.server_log_path()
+        self._log_file = open(log_path, "w")
+
+        self.audit.log_command(self.server_cmd, description="start vllm server")
+        self.audit.log_event("server_started", cmd=self.server_cmd, port=self.port)
+
+        self._process = subprocess.Popen(
+            self.server_cmd,
+            shell=True,
+            stdout=self._log_file,
+            stderr=subprocess.STDOUT,
+            env=os.environ.copy(),
+            preexec_fn=os.setsid,
+        )
+
+        if not self._wait_healthy():
+            self.stop()
+            raise ServerError(
+                f"Server did not become healthy within {self.health_timeout}s. "
+                f"Check {log_path}"
+            )
+
+        self.audit.log_event("server_ready", pid=self.pid, port=self.port)
+
+    def _wait_healthy(self) -> bool:
+        """Poll /v1/models until 200 with data, or timeout."""
+        url = f"{self.base_url}/v1/models"
+        deadline = time.monotonic() + self.health_timeout
+
+        while time.monotonic() < deadline:
+            if self._process.poll() is not None:
+                return False
+            try:
+                resp = requests.get(url, timeout=self.HEALTH_CHECK_TIMEOUT)
+                if resp.status_code == 200 and resp.json().get("data"):
+                    return True
+            except (requests.RequestException, ValueError):
+                pass
+            time.sleep(self.health_interval)
+        return False
+
+    def stop(self) -> None:
+        """Kill the server process tree and close the log file."""
+        if self._process and self._process.poll() is None:
+            try:
+                pgid = os.getpgid(self._process.pid)
+                os.killpg(pgid, signal.SIGTERM)
+                try:
+                    self._process.wait(timeout=self.SIGTERM_WAIT)
+                except subprocess.TimeoutExpired:
+                    os.killpg(pgid, signal.SIGKILL)
+                    self._process.wait(timeout=self.SIGKILL_WAIT)
+            except (ProcessLookupError, OSError):
+                pass
+
+        if self._log_file and not self._log_file.closed:
+            self._log_file.close()
+
+        self.audit.log_event("server_stopped", pid=self.pid)
+
+    def is_running(self) -> bool:
+        return self._process is not None and self._process.poll() is None
+
+    def __del__(self):
+        if self._log_file and not self._log_file.closed:
+            self._log_file.close()

--- a/ai_skills/evaluation/eval-agent/eval_agent/summary.py
+++ b/ai_skills/evaluation/eval-agent/eval_agent/summary.py
@@ -1,0 +1,181 @@
+"""Generate summary data JSON from an evaluation run.
+
+Handles both lm-eval output (single JSON file per task+seed) and
+lighteval output (directory per task+seed containing JSON files).
+"""
+
+import json
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+
+def _load_lm_eval_scores(result_file: Path) -> dict[str, float]:
+    """Extract numeric metric scores from an lm-eval result JSON."""
+    scores: dict[str, float] = {}
+    try:
+        data = json.loads(result_file.read_text())
+        for task_data in data.get("results", {}).values():
+            for key, value in task_data.items():
+                if "_stderr" not in key and key not in ("name", "alias", "sample_len"):
+                    if isinstance(value, (int, float)):
+                        scores[key] = value
+    except Exception as e:
+        print(f"WARNING: Could not parse lm-eval result {result_file}: {e}", file=sys.stderr)
+    return scores
+
+
+def _load_lighteval_scores(result_dir: Path) -> dict[str, float]:
+    """Extract numeric metric scores from a lighteval output directory.
+
+    lighteval writes results_*.json files inside its output directory tree.
+    We scan recursively for any JSON with a top-level 'results' key.
+    """
+    scores: dict[str, float] = {}
+    for json_file in result_dir.rglob("results_*.json"):
+        try:
+            data = json.loads(json_file.read_text())
+            results = data.get("results", {})
+            for task_data in results.values():
+                if isinstance(task_data, dict):
+                    for key, value in task_data.items():
+                        if isinstance(value, (int, float)):
+                            scores[key] = value
+        except Exception as e:
+            print(f"WARNING: Could not parse lighteval result {json_file}: {e}", file=sys.stderr)
+    return scores
+
+
+def generate_summary_data(run_dir: Path) -> dict:
+    """Extract all deterministic facts from a run for the agent to summarize."""
+    manifest_path = run_dir / "manifest.json"
+    with open(manifest_path) as f:
+        manifest = json.load(f)
+
+    events_path = run_dir / "events.jsonl"
+    events = []
+    if events_path.exists():
+        for line in events_path.read_text().splitlines():
+            line = line.strip()
+            if line:
+                try:
+                    events.append(json.loads(line))
+                except json.JSONDecodeError:
+                    pass
+
+    results_dir = run_dir / "results"
+    if not results_dir.exists():
+        return _empty_summary(manifest, events, error="Results directory missing")
+
+    # Build a map of (task_name, seed) -> harness from manifest benchmarks
+    harness_map: dict[str, str] = {b["name"]: b.get("harness", "lm-eval") for b in manifest.get("benchmarks", [])}
+
+    # Collect scores per task, averaged across seeds
+    scores_by_task: dict[str, dict[str, list[float]]] = defaultdict(lambda: defaultdict(list))
+
+    for completed_event in (e for e in events if e["event"] == "eval_completed"):
+        task_name = completed_event["task"]
+        seed = completed_event["seed"]
+        harness = harness_map.get(task_name, "lm-eval")
+
+        if harness == "lm-eval":
+            result_file = results_dir / f"{task_name}_seed{seed}.json"
+            scores = _load_lm_eval_scores(result_file) if result_file.exists() else {}
+        else:
+            result_dir = results_dir / f"{task_name}_seed{seed}"
+            scores = _load_lighteval_scores(result_dir) if result_dir.exists() else {}
+
+        for metric, value in scores.items():
+            scores_by_task[task_name][metric].append(value)
+
+    # Average scores across seeds
+    results: dict[str, dict] = {}
+    for task, metrics in scores_by_task.items():
+        results[task] = {
+            metric: {
+                "mean": sum(vals) / len(vals),
+                "values": vals,
+                "count": len(vals),
+            }
+            for metric, vals in metrics.items()
+        }
+
+    # Timing per (task, seed)
+    task_timings: dict[tuple, dict] = {}
+    for e in events:
+        key = (e.get("task"), e.get("seed"))
+        if e["event"] == "eval_started":
+            task_timings[key] = {"start": e["elapsed_s"]}
+        elif e["event"] == "eval_completed" and key in task_timings:
+            task_timings[key]["duration"] = e["elapsed_s"] - task_timings[key]["start"]
+
+    timing_by_task: dict[str, list] = defaultdict(list)
+    for (task, seed), times in task_timings.items():
+        if task and "duration" in times:
+            timing_by_task[task].append({"seed": seed, "duration_seconds": times["duration"]})
+
+    timing_stats: dict[str, dict] = {}
+    for task, timings in timing_by_task.items():
+        durations = [t["duration_seconds"] for t in timings]
+        timing_stats[task] = {
+            "mean": sum(durations) / len(durations),
+            "min": min(durations),
+            "max": max(durations),
+            "per_seed": timings,
+            "anomaly": max(durations) > 2 * min(durations) if len(durations) > 1 else False,
+        }
+
+    run_start = next((e for e in events if e["event"] == "run_started"), None)
+    server_ready = next((e for e in events if e["event"] == "server_ready"), None)
+    server_stopped = next((e for e in events if e["event"] == "server_stopped"), None)
+    run_complete = next((e for e in events if e["event"] == "run_completed"), None)
+    completed = [e for e in events if e["event"] == "eval_completed"]
+    failed = [e for e in events if e["event"] == "eval_failed"]
+
+    return {
+        "run_id": manifest["run_id"],
+        "model": manifest["model"],
+        "category": manifest["category"],
+        "config": {
+            "server_cmd": manifest["server_cmd"],
+            "base_gen_params": manifest["base_gen_params"],
+            "port": manifest["port"],
+            "num_concurrent": manifest["num_concurrent"],
+            "timeout": manifest["timeout"],
+            "max_length": manifest["max_length"],
+            "seeds": manifest.get("seeds", []),
+        },
+        "timing": {
+            "total_seconds": run_complete["elapsed_s"] if run_complete else 0,
+            "server_startup_seconds": server_ready["elapsed_s"] if server_ready else 0,
+            "by_task": timing_stats,
+        },
+        "results": results,
+        "status": {
+            "completed": len(completed),
+            "failed": len(failed),
+            "failures": [
+                {"task": e["task"], "seed": e["seed"], "log": e.get("log")}
+                for e in failed
+            ],
+        },
+        "timestamps": {
+            "start": run_start["timestamp"] if run_start else None,
+            "server_ready": server_ready["timestamp"] if server_ready else None,
+            "server_stopped": server_stopped["timestamp"] if server_stopped else None,
+            "complete": run_complete["timestamp"] if run_complete else None,
+        },
+    }
+
+
+def _empty_summary(manifest: dict, events: list, error: str) -> dict:
+    return {
+        "run_id": manifest["run_id"],
+        "model": manifest["model"],
+        "category": manifest["category"],
+        "config": {},
+        "timing": {},
+        "results": {},
+        "status": {"completed": 0, "failed": 0, "failures": [], "error": error},
+        "timestamps": {},
+    }

--- a/ai_skills/evaluation/eval-agent/pyproject.toml
+++ b/ai_skills/evaluation/eval-agent/pyproject.toml
@@ -1,0 +1,24 @@
+[build-system]
+requires = ["setuptools>=68.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "eval-agent"
+version = "0.1.0"
+description = "Unified LLM evaluation orchestrator (lm-eval + lighteval) via vLLM + canhazgpu"
+requires-python = ">=3.10"
+dependencies = [
+    "pyyaml>=6.0",
+    "requests>=2.31",
+    "psutil>=5.9",
+    "huggingface-hub>=0.20",
+]
+
+# No [eval] extras: lm-eval and lighteval live in their own workspace venvs
+# (.venvs/lm-eval/ and .venvs/lighteval/), installed separately at runtime.
+
+[project.scripts]
+eval-agent = "eval_agent.cli:main"
+
+[tool.setuptools.packages.find]
+include = ["eval_agent*"]

--- a/ai_skills/evaluation/eval-agent/requirements.txt
+++ b/ai_skills/evaluation/eval-agent/requirements.txt
@@ -1,0 +1,4 @@
+pyyaml>=6.0
+requests>=2.31
+psutil>=5.9
+huggingface-hub>=0.20


### PR DESCRIPTION
Unified LLM evaluation orchestrator that runs lm-eval and lighteval benchmark suites (GSM8k, MMLU, IFEval, Math-500, AIME25, GPQA Diamond, LiveCodeBench) against a model served by vLLM with GPU reservation via canhazgpu. Supports instruct, reasoning, coding, and long_context categories.