### PR TITLE
Add Model Compression Skill (int, fp8, nvfp4 and mxfp4)

### DIFF
--- a/ai_skills/compress_models/SKILL.md
+++ b/ai_skills/compress_models/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: compress_models
+description: >
+  Quantize / compress a HuggingFace model using llm-compressor.
+  Routes to the correct scheme-specific skill (FP8, INT, NVFP4, MXFP4) based on the user's request.
+  Triggers on: "compress", "quantize", "quantization", "fp8", "FP8_DYNAMIC", "FP8_BLOCK", "MXFP8",
+  "int8", "int4", "W8A8", "W4A16", "GPTQ", "SmoothQuant", "integer quantization",
+  "nvfp4", "NVFP4", "fp4 nvidia", "fp4 hopper", "fp4 blackwell", "h100 fp4",
+  "mxfp4", "MXFP4", "fp4 amd", "mi300x quantization",
+  "compress model", "quantize model", "model compression".
+allowed-tools: [Read, Write, Glob, Shell, AskQuestion, WebFetch]
+---
+
+# Model Compression — Unified Skill Router
+
+This skill determines the appropriate quantization scheme and delegates to the scheme-specific sub-skill.
+
+## Step 1 — Determine the quantization scheme
+
+Analyze the user's request for explicit or implicit scheme indicators. Use the table below to classify:
+
+| Scheme   | Trigger keywords / phrases | Hardware target |
+|----------|---------------------------|-----------------|
+| **FP8**  | `fp8`, `FP8_DYNAMIC`, `FP8_BLOCK`, `MXFP8`, `w8a8 fp8`, `float8` | NVIDIA Ampere+ (FP8_DYNAMIC), Hopper/Blackwell (FP8_BLOCK), AMD MI300X (MXFP8) |
+| **INT**  | `int8`, `int4`, `W8A8` (integer context), `W4A16`, `GPTQ`, `SmoothQuant`, `integer quantization` | NVIDIA Turing+ (W8A8), Ampere+ (W4A16) |
+| **NVFP4** | `nvfp4`, `NVFP4`, `nv fp4`, `fp4 nvidia`, `fp4 hopper`, `fp4 blackwell`, `h100 fp4` | NVIDIA H100 / Blackwell (sm90+) |
+| **MXFP4** | `mxfp4`, `MXFP4`, `mx fp4`, `fp4 amd`, `mi300x quantization` | AMD MI300X |
+
+### If one scheme is clear from the request:
+
+Proceed directly to **Step 2** with the identified scheme.
+
+### If multiple schemes are requested:
+
+The user may request several quantization schemes at once (e.g., "quantize to fp8 and nvfp4", "compress this model in int8, fp8, and mxfp4"). This is fully supported.
+
+1. Identify **all** requested schemes from the user's message.
+2. Collect shared information **once** in Step 1 of the first sub-skill (MODEL_ID, model type, virtual environment, additional dependencies, HF upload preferences). Reuse these answers for all subsequent schemes — do not re-ask.
+3. Execute each scheme **sequentially** by following Step 2 for each one. The environment setup (venv creation, dependency installation) only needs to happen once for the first scheme; subsequent schemes reuse the same environment.
+4. Each scheme produces its own quantization script, its own output directory (with a scheme-specific suffix), and its own vLLM verification run.
+5. If the user wants to upload to HF, each scheme gets its own repo (e.g., `RedHatAI/Model-FP8-dynamic`, `RedHatAI/Model-NVFP4`).
+
+### If the scheme is ambiguous or not specified:
+
+Ask the user to choose using `AskQuestion` (with `allow_multiple: true`) with the following options:
+
+- **FP8** — 8-bit floating point. No calibration required (FP8_DYNAMIC / FP8_BLOCK) or calibration-free MX format (MXFP8). ~50% memory reduction. Broadest hardware support.
+- **INT (W4A16)** — 4-bit integer weight-only (GPTQ). ~75% memory reduction. Requires calibration. Best compression-to-accuracy ratio.
+- **INT (W8A8)** — 8-bit integer weights and activations (SmoothQuant + GPTQ). ~50% memory reduction. Requires calibration. Best INT8 quality.
+- **NVFP4** — 4-bit floating point for NVIDIA H100/Blackwell. ~75% memory reduction. Requires calibration.
+- **MXFP4** — 4-bit MX floating point for AMD MI300X. ~75% memory reduction. Calibration optional.
+
+### Disambiguation hints
+
+- If the user says "fp4" without specifying vendor, ask whether they target NVIDIA (→ NVFP4) or AMD (→ MXFP4).
+- If the user says "W8A8" without specifying int vs fp8, ask whether they want integer (→ INT W8A8) or floating point (→ FP8 FP8_DYNAMIC).
+- If the user simply says "compress" or "quantize" without a scheme, present all options (with multi-select enabled).
+
+## Step 2 — Delegate to the scheme-specific skill
+
+Once the scheme(s) are determined, read the corresponding sub-skill(s) and follow each from its Step 1 onward. The sub-skill files are located relative to this file:
+
+| Scheme   | Sub-skill path |
+|----------|---------------|
+| FP8      | `fp8/SKILL.md` |
+| INT      | `int/SKILL.md` |
+| NVFP4    | `nvfp4/SKILL.md` |
+| MXFP4    | `mxfp4/SKILL.md` |
+
+**Action:** Resolve the sub-skill's absolute path by replacing the filename of this skill file's own path with the relative sub-skill path. For example, if this file was read from `/any/where/compress_models/SKILL.md`, then the FP8 sub-skill is at `/any/where/compress_models/fp8/SKILL.md`. Use the `Read` tool to read that file, then execute every step in that sub-skill exactly as written.
+
+### When multiple schemes are requested:
+
+1. Read **all** selected sub-skill files.
+2. Run the **first** sub-skill end-to-end (Steps 1–10). This handles all shared setup (venv, dependencies, GPU check) and the first quantization + verification.
+3. For each **subsequent** sub-skill, skip Steps 1–3 (information gathering, GPU check, environment setup — already done) and begin from Step 4 (check for existing examples) onward. Reuse the same virtual environment, MODEL_ID, model type, and GPU count.
+4. After all schemes complete, report a summary of all results to the user (scheme, output directory, vLLM verification status, upload status).
+
+## Quick Reference — Scheme Comparison
+
+| Property | FP8_DYNAMIC | FP8_BLOCK | MXFP8 | W4A16 (INT) | W8A8 (INT) | NVFP4 | MXFP4 |
+|----------|------------|-----------|-------|-------------|------------|-------|-------|
+| Weight bits | 8 | 8 | 8 | 4 | 8 | 4 | 4 |
+| Activation bits | 8 | 8 | 8 | 16 (fp16) | 8 | 4 | 4 |
+| Calibration required | No | No | No | Yes | Yes | Yes | Optional |
+| Memory reduction | ~50% | ~50% | ~50% | ~75% | ~50% | ~75% | ~75% |
+| Min GPU | Ampere | Hopper | MI300X | Ampere | Turing | H100 (sm90+) | MI300X |
+| Algorithm | QuantizationModifier | QuantizationModifier | QuantizationModifier | GPTQModifier | SmoothQuant + GPTQ | QuantizationModifier or GPTQModifier | QuantizationModifier or GPTQModifier |

--- a/ai_skills/compress_models/SKILL.md
+++ b/ai_skills/compress_models/SKILL.md
@@ -15,6 +15,42 @@ allowed-tools: [Read, Write, Glob, Shell, AskQuestion, WebFetch]
 
 This skill determines the appropriate quantization scheme and delegates to the scheme-specific sub-skill.
 
+## Step 0 — Detect the user's intent
+
+Before routing to a scheme, determine **what the user is asking to do**. The user's request falls into one of these categories:
+
+### A) Upload-only (skip quantization)
+
+The user already has a quantized model on disk and wants to **generate a README and/or upload to Hugging Face**.
+
+**Trigger phrases:** "upload", "push to hub", "create readme", "generate readme", "publish model", "upload to huggingface", "push to hf", combined with a local model directory path.
+
+**Required information — gather from the user (or infer from context):**
+
+1. **SAVE_DIR** — path to the local quantized model directory
+2. **HF_REPO** — target Hugging Face repo name (e.g. `RedHatAI/Qwen3-8B-FP8-dynamic`)
+3. **BASE_MODEL_ID** — the original unquantized model ID (e.g. `Qwen/Qwen3-8B`). If not provided, try to infer from the model directory name or `config.json` inside `SAVE_DIR`.
+4. **Scheme** — the quantization scheme used (FP8_DYNAMIC, FP8_BLOCK, MXFP8, W4A16, W8A8, NVFP4, MXFP4). If not provided, try to infer from the directory name (e.g. `-FP8-dynamic` → FP8_DYNAMIC, `-NVFP4` → NVFP4) or from `config.json` / `quantization_config` inside `SAVE_DIR`.
+5. **Quantization script (optional)** — the Python code used for quantization, to embed in the README's "Creation" section. Ask: "Do you have the quantization script you used? If so, provide the path or paste it. Otherwise this section will be omitted from the README."
+
+**Action:** Once the scheme is identified, read the corresponding sub-skill (see Step 2 table) and jump directly to its **Step 10** (Upload to Hugging Face). Execute Step 10 using the information gathered above.
+
+### B) Verify-only (skip quantization, just run vLLM test)
+
+The user has a quantized model and wants to **verify it loads and generates correctly with vLLM**.
+
+**Trigger phrases:** "test", "verify", "run vllm", "check model", "vllm test", combined with a local model directory path.
+
+**Required information:**
+1. **SAVE_DIR** — path to the local quantized model directory
+2. **TENSOR_PARALLEL_SIZE** — number of GPUs (infer from model size or ask)
+
+**Action:** Read any sub-skill (they all share the same Steps 8–9) and jump directly to **Step 8** (Write and run vLLM verification test), then **Step 9** (Validate results).
+
+### C) Full quantization workflow (default)
+
+The user wants to quantize a model from scratch. Proceed to **Step 1** below.
+
 ## Step 1 — Determine the quantization scheme
 
 Analyze the user's request for explicit or implicit scheme indicators. Use the table below to classify:

--- a/ai_skills/compress_models/fp8/SKILL.md
+++ b/ai_skills/compress_models/fp8/SKILL.md
@@ -1,0 +1,209 @@
+---
+name: fp8_compress
+description: >
+  Generate a working FP8 quantization example script, set up an environment, install dependencies,
+  run quantization with canhazgpu, and verify the compressed model with vLLM.
+  Triggers on: "fp8", "FP8_DYNAMIC", "FP8_BLOCK", "MXFP8", "fp8 example", "quantize to fp8".
+allowed-tools: [Read, Write, Glob, Shell, AskQuestion]
+---
+
+# FP8 Quantization — End-to-End Workflow
+
+Generate a working FP8 quantization script, create an isolated environment, run quantization on GPUs, and verify the result with vLLM.
+
+## Step 1 — Gather information
+
+Ask the user (or infer from context) for:
+
+1. **MODEL_ID** — HuggingFace model ID (e.g. `meta-llama/Meta-Llama-3-8B-Instruct`)
+2. **Scheme variant** — choose one:
+   - `FP8_DYNAMIC` — weights fp8 per-channel, activations fp8 dynamic per-token. No calibration. Broadest hardware support (Ampere+). Recommended default.
+   - `FP8_BLOCK` — weights fp8 with 128x128 block scaling, activations dynamic. No calibration. Best throughput on Hopper/Blackwell.
+   - `MXFP8` — weights and activations in MX fp8 format. No calibration. AMD MI300X target.
+3. **Model type** — dense, MoE, or multimodal (vision/audio)
+4. **Use `model_free_ptq`?** — yes if the model is very large (70B+) and should avoid full GPU load; otherwise use `oneshot`
+5. **Additional dependencies** — Ask: "Do you need any additional pip packages beyond `llmcompressor`, `vllm`, and `torchvision`?"
+
+## Step 2 — Determine GPU requirements
+
+Check available GPUs:
+```bash
+nvidia-smi -L 2>/dev/null | wc -l
+```
+
+Determine how many GPUs are needed based on model size:
+- **Up to 8B parameters** — 1 GPU
+- **8B–30B parameters** — 2 GPUs
+- **30B–70B parameters** — 4 GPUs
+- **70B+ parameters** — 8 GPUs
+
+If the required number of GPUs exceeds what is available, warn the user and ask how to proceed (e.g. use `model_free_ptq` instead, or wait for resources).
+
+Set `TENSOR_PARALLEL_SIZE` to the number of GPUs needed (used later for vLLM verification).
+
+## Step 3 — Create virtual environment and install dependencies
+
+Create an isolated environment using `uv`:
+
+```bash
+uv venv compress_model --python 3.12
+source compress_model/bin/activate
+```
+
+Install core dependencies:
+```bash
+uv pip install llmcompressor vllm torchvision
+```
+
+If the user specified additional dependencies, install them too:
+```bash
+uv pip install <additional_packages>
+```
+
+## Step 4 — Choose the quantization template and write the script
+
+### `oneshot` with `QuantizationModifier` (standard path)
+
+```python
+from compressed_tensors.offload import dispatch_model
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+from llmcompressor import oneshot
+from llmcompressor.modifiers.quantization import QuantizationModifier
+
+MODEL_ID = "<MODEL_ID>"
+
+# Load model.
+model = AutoModelForCausalLM.from_pretrained(MODEL_ID)
+tokenizer = AutoTokenizer.from_pretrained(MODEL_ID)
+
+recipe = QuantizationModifier(
+    targets="Linear",
+    scheme="<SCHEME>",  # FP8_DYNAMIC | FP8_BLOCK | MXFP8
+    ignore=["lm_head"],  # extend per model type — see Step 5
+)
+
+oneshot(model=model, recipe=recipe)
+
+print("========== SAMPLE GENERATION ==============")
+dispatch_model(model)
+input_ids = tokenizer("Hello my name is", return_tensors="pt").input_ids.to(model.device)
+output = model.generate(input_ids, max_new_tokens=20)
+print(tokenizer.decode(output[0]))
+print("==========================================")
+
+SAVE_DIR = MODEL_ID.rstrip("/").split("/")[-1] + "-<SCHEME>"
+model.save_pretrained(SAVE_DIR)
+tokenizer.save_pretrained(SAVE_DIR)
+```
+
+### `model_free_ptq` (large models, avoids full GPU load)
+
+```python
+from llmcompressor import model_free_ptq
+
+MODEL_ID = "<MODEL_ID>"
+SAVE_DIR = MODEL_ID.rstrip("/").split("/")[-1] + "-<SCHEME>"
+
+model_free_ptq(
+    model_stub=MODEL_ID,
+    save_directory=SAVE_DIR,
+    scheme="<SCHEME>",  # FP8_DYNAMIC | FP8_BLOCK
+    ignore=[
+        "model.embed_tokens",
+        "lm_head",
+        # extend per model type — see Step 5
+    ],
+    max_workers=15,
+    device="cuda:0",
+)
+```
+
+Place the file in the appropriate directory under `examples/`:
+- `quantization_w8a8_fp8/` for FP8_DYNAMIC or FP8_BLOCK (oneshot path)
+- `quantization_w8a8_mxfp8/` for MXFP8
+- `model_free_ptq/` when using `model_free_ptq()`
+
+Name the file `{model_name_slug}_example.py` (e.g. `llama3_example.py`, `gemma4_example.py`).
+
+## Step 5 — Apply model-type adjustments
+
+### Dense models
+`ignore=["lm_head"]` is sufficient in most cases.
+
+### MoE models
+Add gate/router layers to `ignore`. For models that require a custom loading path, wrap the load in `load_context`:
+```python
+from llmcompressor.utils import load_context
+
+with load_context(SpecificModelClass):
+    model = SpecificModelClass.from_pretrained(MODEL_ID)
+```
+Common MoE ignore additions:
+- Qwen MoE: `"re:.*mlp.gate$"`, `"re:.*shared_expert_gate.*"`
+- Llama4 / Gemma4 MoE: `"re:.*router"`, `"Llama4TextAttention"`
+
+For FP8_BLOCK on MoE, also skip attention: `"re:.*self_attn"`.
+
+### Multimodal (vision / audio)
+- Use `AutoProcessor` instead of `AutoTokenizer`
+- Use the appropriate model class (e.g. `Gemma4ForConditionalGeneration`, `Llama4ForConditionalGeneration`) and wrap load in `load_context` if needed
+- Add to `ignore`:
+  - Vision: `"re:.*vision_tower.*"`, `"re:.*vision_model.*"`, `"re:.*multi_modal_projector.*"`
+  - Audio: `"re:.*audio_tower.*"`
+  - Embedding projections: `"re:.*embed.*"` (model-specific)
+
+## Step 6 — Run quantization with canhazgpu
+
+Launch the quantization script using `canhazgpu` with the required number of GPUs:
+
+```bash
+canhazgpu run --gpus <NUM_GPUS> -- python3 <script_name>.py
+```
+
+Wait for the quantization to complete. Monitor the output for errors.
+
+## Step 7 — Write and run vLLM verification test
+
+After quantization completes, create a `vllm_test.py` script to verify the compressed model loads and generates reasonable output:
+
+```python
+from vllm import LLM, SamplingParams
+
+if __name__ == '__main__':
+    model_name = "<SAVE_DIR>"
+    llm = LLM(model=model_name, tensor_parallel_size=<TENSOR_PARALLEL_SIZE>, trust_remote_code=True)
+
+    outputs = llm.generate(
+        ["Describe Large Language Models"],
+        SamplingParams(temperature=0.8, max_tokens=200)
+    )
+
+    print(outputs[0].outputs[0].text)
+```
+
+Run the vLLM test:
+```bash
+canhazgpu run --gpus <NUM_GPUS> -- python3 vllm_test.py
+```
+
+## Step 8 — Validate results
+
+After running `vllm_test.py`, check:
+1. The model loaded successfully without errors.
+2. The generated output is coherent and reasonable (not garbage/random tokens).
+
+If both conditions are met, the FP8 quantization is successful. Report the result to the user.
+
+If the output is garbled or the model fails to load, investigate:
+- Check if `ignore` layers need adjustment
+- Verify the correct scheme was used for the hardware
+- Ensure tensor_parallel_size matches available GPUs
+
+## Notes
+- `FP8_DYNAMIC` is the recommended starting point — no calibration required, broad hardware support.
+- `FP8_BLOCK` is preferred for Hopper/Blackwell throughput.
+- `MXFP8` targets AMD MI300X.
+- Neither scheme requires a calibration dataset; `oneshot(model=model, recipe=recipe)` with no `dataset` argument is correct.
+- `save_compressed=True` is optional — the checkpoint saves in compressed-tensors format either way. Omit unless explicitly requested.
+- The virtual environment name defaults to `compress_model` but can be customized if the user prefers.

--- a/ai_skills/compress_models/int/SKILL.md
+++ b/ai_skills/compress_models/int/SKILL.md
@@ -1,0 +1,450 @@
+---
+name: int_compress
+description: >
+  Generate a working INT quantization example script (W4A16 or W8A8), set up an environment,
+  install dependencies, run quantization with canhazgpu, and verify the compressed model with vLLM.
+  Triggers on: "int8", "int4", "W8A8", "W4A16", "GPTQ", "SmoothQuant", "integer quantization",
+  "quantize to int8", "quantize to int4".
+allowed-tools: [Read, Write, Glob, Shell, AskQuestion, WebFetch]
+---
+
+# INT Quantization — End-to-End Workflow
+
+Generate a working INT quantization script, create an isolated environment, run quantization on GPUs, and verify the result with vLLM.
+
+## Step 1 — Gather information
+
+Ask the user (or infer from context) for:
+
+1. **MODEL_ID** — HuggingFace model ID (e.g. `meta-llama/Meta-Llama-3-8B-Instruct`)
+2. **Scheme variant** — choose one:
+   - `W4A16` — 4-bit integer weight-only quantization using GPTQ with group size 128. Activations remain in fp16. Good balance of compression and accuracy. Requires calibration. GPU: Ampere+ (SM80+).
+   - `W8A8` — 8-bit integer weight and activation quantization. Uses SmoothQuant preprocessing + GPTQ for weights. Dynamic per-token activation quantization. Requires calibration. GPU: Turing+ (SM75+).
+3. **Model type** — dense, MoE, or multimodal (vision/audio)
+4. **Use `model_free_ptq`?** — yes if the model is very large (70B+) and should avoid full GPU load; otherwise use `oneshot`
+5. **Calibration dataset** — default is `HuggingFaceH4/ultrachat_200k` (split `train_sft`). Ask if the user wants a different dataset.
+6. **Calibration samples** — default is 512. Ask if the user wants to change.
+7. **Existing virtual environment** — Ask: "Do you have an existing virtual environment you'd like to use? If so, provide the path (e.g. `/data/user/myenv`). Otherwise a new one will be created."
+8. **Additional dependencies** — Ask: "Do you need any additional pip packages beyond `llmcompressor`, `vllm`, `torchvision`, and `datasets`?"
+9. **HF repo name (optional)** — Ask: "Do you want to upload the quantized model to a Hugging Face repo? If so, provide the repo name (e.g. `RedHatAI/Qwen3-8B-W8A8-INT8`). Leave blank to skip upload."
+
+## Step 2 — Determine GPU requirements
+
+Check available GPUs:
+```bash
+nvidia-smi -L 2>/dev/null | wc -l
+```
+
+Determine how many GPUs are needed based on model size:
+- **Up to 8B parameters** — 1 GPU
+- **8B–30B parameters** — 2 GPUs
+- **30B–70B parameters** — 4 GPUs
+- **70B+ parameters** — 8 GPUs
+
+If the required number of GPUs exceeds what is available, warn the user and ask how to proceed (e.g. use `model_free_ptq` instead, or wait for resources).
+
+Set `TENSOR_PARALLEL_SIZE` to the number of GPUs needed (used later for vLLM verification).
+
+## Step 3 — Set up virtual environment and install dependencies
+
+### If the user provided an existing virtual environment path:
+
+Activate it directly:
+```bash
+source <location>/bin/activate
+```
+
+### If no existing environment was provided:
+
+Create a new isolated environment using `uv`:
+```bash
+uv venv compress_model --python 3.12
+source compress_model/bin/activate
+```
+
+### Install dependencies
+
+Always install `llmcompressor` from the git source:
+```bash
+uv pip install git+https://github.com/vllm-project/llm-compressor.git
+uv pip install vllm torchvision datasets
+```
+
+If the user specified additional dependencies, install them too:
+```bash
+uv pip install <additional_packages>
+```
+
+## Step 4 — Check for existing examples on GitHub
+
+Before writing a script from scratch, check the upstream examples directory for an existing script that targets the same model architecture:
+
+**GitHub directories:**
+- W4A16: `https://github.com/vllm-project/llm-compressor/tree/main/examples/quantization_w4a16`
+- W8A8: `https://github.com/vllm-project/llm-compressor/tree/main/examples/quantization_w8a8_int8`
+
+1. Fetch the directory listing using `WebFetch` or browse the GitHub URL to see available example files.
+2. Identify if an example exists for the same model family / architecture as the user's MODEL_ID. For example:
+   - User wants to quantize `meta-llama/Llama-4-Scout-17B-16E-Instruct` → look for `llama4_example.py`
+   - User wants to quantize `Qwen/Qwen3-32B` → look for `qwen3_example.py`
+   - User wants to quantize `google/gemma-3-27b-it` → look for `gemma3_example.py`
+3. **If a matching example is found:**
+   - Download the raw file from GitHub (e.g. `https://raw.githubusercontent.com/vllm-project/llm-compressor/main/examples/quantization_w4a16/<filename>.py` or `https://raw.githubusercontent.com/vllm-project/llm-compressor/main/examples/quantization_w8a8_int8/<filename>.py`)
+   - Replace the `MODEL_ID` value in the script with the user's MODEL_ID
+   - Adjust the `SAVE_DIR` if needed
+   - Use this as the quantization script — skip Step 5 template generation
+4. **If no matching example is found:**
+   - Proceed to Step 5 and generate the script from the template
+
+## Step 5 — Choose the quantization template and write the script (fallback)
+
+### W4A16 — `oneshot` with `GPTQModifier` (INT4 weight-only)
+
+```python
+from compressed_tensors.offload import dispatch_model
+from datasets import load_dataset
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+from llmcompressor import oneshot
+from llmcompressor.modifiers.gptq import GPTQModifier
+
+MODEL_ID = "<MODEL_ID>"
+
+model = AutoModelForCausalLM.from_pretrained(MODEL_ID)
+tokenizer = AutoTokenizer.from_pretrained(MODEL_ID)
+
+NUM_CALIBRATION_SAMPLES = 512
+MAX_SEQUENCE_LENGTH = 2048
+
+ds = load_dataset("<CALIBRATION_DATASET>", split="<SPLIT>")
+ds = ds.shuffle(seed=42).select(range(NUM_CALIBRATION_SAMPLES))
+
+def tokenize(sample):
+    return tokenizer(
+        sample["text"],
+        padding=False,
+        max_length=MAX_SEQUENCE_LENGTH,
+        truncation=True,
+        add_special_tokens=False,
+    )
+
+ds = ds.map(tokenize, remove_columns=ds.column_names)
+
+recipe = GPTQModifier(targets="Linear", scheme="W4A16", ignore=["lm_head"])
+
+oneshot(
+    model=model,
+    dataset=ds,
+    recipe=recipe,
+    max_seq_length=MAX_SEQUENCE_LENGTH,
+    num_calibration_samples=NUM_CALIBRATION_SAMPLES,
+)
+
+print("========== SAMPLE GENERATION ==============")
+dispatch_model(model)
+input_ids = tokenizer("Hello my name is", return_tensors="pt").input_ids.to(model.device)
+output = model.generate(input_ids, max_new_tokens=20)
+print(tokenizer.decode(output[0]))
+print("==========================================")
+
+SAVE_DIR = MODEL_ID.rstrip("/").split("/")[-1] + "-W4A16-G128"
+model.save_pretrained(SAVE_DIR, save_compressed=True)
+tokenizer.save_pretrained(SAVE_DIR)
+```
+
+### W8A8 — `oneshot` with `SmoothQuantModifier` + `GPTQModifier` (INT8 weight & activation)
+
+```python
+from compressed_tensors.offload import dispatch_model
+from datasets import load_dataset
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+from llmcompressor import oneshot
+from llmcompressor.modifiers.gptq import GPTQModifier
+from llmcompressor.modifiers.transform.smoothquant import SmoothQuantModifier
+
+MODEL_ID = "<MODEL_ID>"
+
+model = AutoModelForCausalLM.from_pretrained(MODEL_ID)
+tokenizer = AutoTokenizer.from_pretrained(MODEL_ID)
+
+NUM_CALIBRATION_SAMPLES = 512
+MAX_SEQUENCE_LENGTH = 2048
+
+ds = load_dataset("<CALIBRATION_DATASET>", split="<SPLIT>")
+ds = ds.shuffle(seed=42).select(range(NUM_CALIBRATION_SAMPLES))
+
+def tokenize(sample):
+    return tokenizer(
+        sample["text"],
+        padding=False,
+        max_length=MAX_SEQUENCE_LENGTH,
+        truncation=True,
+        add_special_tokens=False,
+    )
+
+ds = ds.map(tokenize, remove_columns=ds.column_names)
+
+recipe = [
+    SmoothQuantModifier(smoothing_strength=0.8),
+    GPTQModifier(targets="Linear", scheme="W8A8", ignore=["lm_head"]),
+]
+
+oneshot(
+    model=model,
+    dataset=ds,
+    recipe=recipe,
+    max_seq_length=MAX_SEQUENCE_LENGTH,
+    num_calibration_samples=NUM_CALIBRATION_SAMPLES,
+)
+
+print("========== SAMPLE GENERATION ==============")
+dispatch_model(model)
+input_ids = tokenizer("Hello my name is", return_tensors="pt").input_ids.to(model.device)
+output = model.generate(input_ids, max_new_tokens=20)
+print(tokenizer.decode(output[0]))
+print("==========================================")
+
+SAVE_DIR = MODEL_ID.rstrip("/").split("/")[-1] + "-W8A8-Dynamic-Per-Token"
+model.save_pretrained(SAVE_DIR, save_compressed=True)
+tokenizer.save_pretrained(SAVE_DIR)
+```
+
+### `model_free_ptq` (large models, avoids full GPU load)
+
+```python
+from llmcompressor import model_free_ptq
+
+MODEL_ID = "<MODEL_ID>"
+SAVE_DIR = MODEL_ID.rstrip("/").split("/")[-1] + "-<SCHEME_SUFFIX>"
+
+model_free_ptq(
+    model_stub=MODEL_ID,
+    save_directory=SAVE_DIR,
+    scheme="<SCHEME>",  # W4A16 | W8A8
+    ignore=[
+        "model.embed_tokens",
+        "lm_head",
+        # extend per model type — see Step 6
+    ],
+    max_workers=15,
+    device="cuda:0",
+)
+```
+
+Place the file in the appropriate directory under `examples/`:
+- `quantization_w4a16/` for W4A16 (INT4 weight-only)
+- `quantization_w8a8_int8/` for W8A8 (INT8 weight & activation)
+- `model_free_ptq/` when using `model_free_ptq()`
+
+Name the file `{model_name_slug}_example.py` (e.g. `llama3_example.py`, `gemma4_example.py`).
+
+## Step 6 — Apply model-type adjustments
+
+### Dense models
+`ignore=["lm_head"]` is sufficient in most cases.
+
+### MoE models
+Add gate/router layers to `ignore`. For models that require a custom loading path, wrap the load in `load_context`:
+```python
+from llmcompressor.utils import load_context
+
+with load_context(SpecificModelClass):
+    model = SpecificModelClass.from_pretrained(MODEL_ID)
+```
+Common MoE ignore additions:
+- Qwen MoE: `"re:.*mlp.gate$"`, `"re:.*shared_expert_gate.*"`
+- Llama4 / Gemma4 MoE: `"re:.*router"`, `"Llama4TextAttention"`
+
+### Multimodal (vision / audio)
+- Use `AutoProcessor` instead of `AutoTokenizer`
+- Use the appropriate model class (e.g. `Gemma4ForConditionalGeneration`, `Llama4ForConditionalGeneration`) and wrap load in `load_context` if needed
+- Add to `ignore`:
+  - Vision: `"re:.*vision_tower.*"`, `"re:.*vision_model.*"`, `"re:.*multi_modal_projector.*"`
+  - Audio: `"re:.*audio_tower.*"`
+  - Embedding projections: `"re:.*embed.*"` (model-specific)
+
+## Step 7 — Run quantization with canhazgpu
+
+Launch the quantization script using `canhazgpu` with the required number of GPUs:
+
+```bash
+canhazgpu run --gpus <NUM_GPUS> -- python3 <script_name>.py
+```
+
+Wait for the quantization to complete. Monitor the output for errors.
+
+**Note:** INT quantization (both W4A16 and W8A8) requires calibration and takes significantly longer than FP8 (which has no calibration). Expect longer runtimes, especially for larger models.
+
+## Step 8 — Write and run vLLM verification test
+
+After quantization completes, create a `vllm_test.py` script to verify the compressed model loads and generates reasonable output:
+
+```python
+from vllm import LLM, SamplingParams
+
+if __name__ == '__main__':
+    model_name = "<SAVE_DIR>"
+    llm = LLM(model=model_name, tensor_parallel_size=<TENSOR_PARALLEL_SIZE>, trust_remote_code=True)
+
+    outputs = llm.generate(
+        ["Describe Large Language Models"],
+        SamplingParams(temperature=0.8, max_tokens=200)
+    )
+
+    print(outputs[0].outputs[0].text)
+```
+
+Run the vLLM test:
+```bash
+canhazgpu run --gpus <NUM_GPUS> -- python3 vllm_test.py
+```
+
+## Step 9 — Validate results
+
+After running `vllm_test.py`, check:
+1. The model loaded successfully without errors.
+2. The generated output is coherent and reasonable (not garbage/random tokens).
+
+If both conditions are met, the INT quantization is successful. Report the result to the user.
+
+If the output is garbled or the model fails to load, investigate:
+- Check if `ignore` layers need adjustment
+- Verify the calibration dataset is appropriate for the model
+- For W8A8, try adjusting SmoothQuant `smoothing_strength` (default 0.8, try 0.5–1.0)
+- Ensure tensor_parallel_size matches available GPUs
+
+## Step 10 — Upload to Hugging Face (optional)
+
+**Skip this step entirely if the user did not provide an HF repo name in Step 1.**
+
+If the user provided a repo name, upload the quantized model directory and a generated README.
+
+### 10a — Authenticate
+
+Pick up the HF token from the user's environment:
+```bash
+echo $HF_TOKEN
+```
+If `$HF_TOKEN` is not set, try `$HUGGING_FACE_HUB_TOKEN`. If neither is set, ask the user to provide one or run `huggingface-cli login`.
+
+### 10b — Generate README.md
+
+Create a `README.md` inside the `<SAVE_DIR>` directory. The README must be **specific to the model being quantized**. Use the template below and fill in all placeholders:
+
+- `<HF_REPO>` — the full repo name (e.g. `RedHatAI/Qwen3-8B-W8A8-INT8`)
+- `<BASE_MODEL_ID>` — the original unquantized model (e.g. `Qwen/Qwen3-8B`)
+- `<MODEL_ARCH>` — the model's architecture class (e.g. `Qwen3ForCausalLM`, `LlamaForCausalLM`). Determine from the model's `config.json` `architectures` field.
+- `<SCHEME>` — the quantization scheme used (`W4A16` or `W8A8`)
+- `<SCHEME_DESCRIPTION>` — scheme-specific text:
+  - W4A16: "Weights are quantized to 4-bit integers using GPTQ with group size 128. Activations remain in fp16. Calibration data is required."
+  - W8A8: "Weights are quantized to 8-bit integers using GPTQ. Activations are quantized with a symmetric dynamic per-token scheme. SmoothQuant is applied to smooth outlier activations before quantization. Calibration data is required."
+- `<WEIGHT_BITS>` — `INT4` for W4A16, `INT8` for W8A8
+- `<ACTIVATION_BITS>` — `FP16` for W4A16, `INT8` for W8A8
+- `<SIZE_REDUCTION>` — `~75%` for W4A16, `~50%` for W8A8
+- `<TENSOR_PARALLEL_SIZE>` — number of GPUs for vLLM
+- `<QUANTIZATION_SCRIPT>` — the actual Python code used for quantization (from Step 4 or 5)
+- `<LANGUAGES>` — infer from the base model card; if unknown, use `en` only
+- `<LICENSE>` — infer from the base model card
+- `<TAGS>` — include the model family tag (e.g. `qwen`, `llama`, `gemma`), `int4` or `int8`, `vllm`, `conversational`, `text-generation-inference`
+- `<PIPELINE_TAG>` — typically `text-generation`
+
+**README template:**
+
+````markdown
+---
+language:
+<LANGUAGES_LIST>
+base_model:
+- <BASE_MODEL_ID>
+pipeline_tag: <PIPELINE_TAG>
+tags:
+<TAGS_LIST>
+license: <LICENSE>
+---
+
+## Model Overview
+- **Model Architecture:** <MODEL_ARCH>
+  - **Input:** Text
+  - **Output:** Text
+- **Model Optimizations:**
+  - **Activation quantization:** <ACTIVATION_BITS>
+  - **Weight quantization:** <WEIGHT_BITS>
+- **Intended Use Cases:** Intended for commercial and research use. Similarly to the base model, this quantized version is intended for assistant-like chat.
+- **Out-of-scope:** Use in any manner that violates applicable laws or regulations (including trade compliance laws).
+- **Version:** 1.0
+- **Model Developers:** RedHat (Neural Magic)
+
+### Model Optimizations
+
+This model was obtained by quantizing weights and activations of [<BASE_MODEL_ID>](https://huggingface.co/<BASE_MODEL_ID>) to <WEIGHT_BITS>/<ACTIVATION_BITS> data types.
+This optimization reduces the number of bits used to represent weights and activations from 16 to <WEIGHT_BITS>, reducing GPU memory requirements (by approximately <SIZE_REDUCTION>) and increasing matrix-multiply compute throughput.
+Weight quantization also reduces disk size requirements by approximately <SIZE_REDUCTION>.
+
+Only weights and activations of the linear operators within transformers blocks are quantized.
+<SCHEME_DESCRIPTION>
+The [llm-compressor](https://github.com/vllm-project/llm-compressor) library is used for quantization.
+
+## Deployment
+
+This model can be deployed efficiently using the [vLLM](https://docs.vllm.ai/en/latest/) backend, as shown in the example below.
+
+```python
+from vllm import LLM, SamplingParams
+from transformers import AutoTokenizer
+
+model_id = "<HF_REPO>"
+number_gpus = <TENSOR_PARALLEL_SIZE>
+sampling_params = SamplingParams(temperature=0.6, top_p=0.95, top_k=20, min_p=0, max_tokens=256)
+
+tokenizer = AutoTokenizer.from_pretrained(model_id)
+messages = [{"role": "user", "content": "Give me a short introduction to large language model."}]
+prompts = tokenizer.apply_chat_template(messages, add_generation_prompt=True, tokenize=False)
+
+llm = LLM(model=model_id, tensor_parallel_size=number_gpus)
+outputs = llm.generate(prompts, sampling_params)
+generated_text = outputs[0].outputs[0].text
+print(generated_text)
+```
+
+## Creation
+
+<details>
+  <summary>Creation details</summary>
+
+  This model was created with [llm-compressor](https://github.com/vllm-project/llm-compressor) by running the code snippet below.
+
+  ```python
+  <QUANTIZATION_SCRIPT>
+  ```
+</details>
+````
+
+Adapt the template as needed:
+- For multimodal models, change Input/Output to reflect vision/audio capabilities
+- For MoE models, mention the MoE architecture in the overview
+- Include any model-family-specific tags or metadata from the base model card
+
+### 10c — Upload to Hugging Face
+
+Upload the entire quantized weight directory (including the generated README.md) to the HF repo:
+
+```bash
+huggingface-cli upload <HF_REPO> <SAVE_DIR> --token $HF_TOKEN
+```
+
+If the repo does not exist yet, create it first:
+```bash
+huggingface-cli repo create <REPO_NAME> --organization <ORG> --type model --token $HF_TOKEN
+```
+
+Verify the upload succeeded by checking the repo page.
+
+## Notes
+- Both `W4A16` and `W8A8` **require calibration data** — unlike FP8, you must provide a dataset.
+- Default calibration: `HuggingFaceH4/ultrachat_200k`, split `train_sft`, 512 samples, max sequence length 2048.
+- `W4A16` is recommended for aggressive compression (~75% size reduction) with good accuracy.
+- `W8A8` is recommended for best INT8 quality — SmoothQuant smooths outlier activations before GPTQ quantization.
+- `save_compressed=True` is used for INT schemes to save in compressed-tensors format.
+- `W4A16` requires Ampere+ GPUs (SM80+); `W8A8` requires Turing+ GPUs (SM75+).
+- The virtual environment name defaults to `compress_model` but can be customized if the user prefers.

--- a/ai_skills/compress_models/mxfp4/SKILL.md
+++ b/ai_skills/compress_models/mxfp4/SKILL.md
@@ -1,0 +1,409 @@
+---
+name: mxfp4_compress
+description: >
+  Generate a working MXFP4 quantization example script, set up an environment, install dependencies,
+  run quantization with canhazgpu, and verify the compressed model with vLLM.
+  Triggers on: "mxfp4", "MXFP4", "mx fp4", "fp4 amd", "mi300x quantization".
+allowed-tools: [Read, Write, Glob, Shell, AskQuestion, WebFetch]
+---
+
+# MXFP4 Quantization — End-to-End Workflow
+
+Generate a working MXFP4 quantization script, create an isolated environment, run quantization on GPUs, and verify the result with vLLM.
+
+Hardware requirement: AMD MI300X for inference. Quantization can run on any GPU.
+
+## Step 1 — Gather information
+
+Ask the user (or infer from context) for:
+
+1. **MODEL_ID** — HuggingFace model ID (e.g. `meta-llama/Meta-Llama-3-8B-Instruct`)
+2. **Algorithm** — choose one:
+   - `QuantizationModifier` — simple PTQ, no calibration data required. Recommended default.
+   - `GPTQModifier` — learned weight rounding, requires calibration data. Better accuracy.
+3. **Model type** — dense, MoE, or multimodal (vision/audio)
+4. **Existing virtual environment** — Ask: "Do you have an existing virtual environment you'd like to use? If so, provide the path (e.g. `/data/user/myenv`). Otherwise a new one will be created."
+5. **Additional dependencies** — Ask: "Do you need any additional pip packages beyond `llmcompressor`, `vllm`, and `torchvision`?"
+6. **HF repo name (optional)** — Ask: "Do you want to upload the quantized model to a Hugging Face repo? If so, provide the repo name (e.g. `RedHatAI/Qwen3-8B-MXFP4`). Leave blank to skip upload."
+
+## Step 2 — Determine GPU requirements
+
+Check available GPUs:
+```bash
+nvidia-smi -L 2>/dev/null | wc -l
+```
+
+Determine how many GPUs are needed based on model size:
+- **Up to 8B parameters** — 1 GPU
+- **8B–30B parameters** — 2 GPUs
+- **30B–70B parameters** — 4 GPUs
+- **70B+ parameters** — 8 GPUs
+
+If the required number of GPUs exceeds what is available, warn the user and ask how to proceed (e.g. reduce model size, or wait for resources).
+
+Set `TENSOR_PARALLEL_SIZE` to the number of GPUs needed (used later for vLLM verification).
+
+## Step 3 — Set up virtual environment and install dependencies
+
+### If the user provided an existing virtual environment path:
+
+Activate it directly:
+```bash
+source <location>/bin/activate
+```
+
+### If no existing environment was provided:
+
+Create a new isolated environment using `uv`:
+```bash
+uv venv compress_model --python 3.12
+source compress_model/bin/activate
+```
+
+### Install dependencies
+
+Always install `llmcompressor` from the git source:
+```bash
+uv pip install git+https://github.com/vllm-project/llm-compressor.git
+uv pip install vllm torchvision
+```
+
+If the user specified additional dependencies, install them too:
+```bash
+uv pip install <additional_packages>
+```
+
+## Step 4 — Check for existing examples on GitHub
+
+Before writing a script from scratch, check the upstream examples directory for an existing script that targets the same model architecture:
+
+**GitHub directory:** `https://github.com/vllm-project/llm-compressor/tree/main/examples/quantization_w4a4_mxfp4`
+
+1. Fetch the directory listing using `WebFetch` or browse the GitHub URL to see available example files.
+2. Identify if an example exists for the same model family / architecture as the user's MODEL_ID. For example:
+   - User wants to quantize `meta-llama/Llama-4-Scout-17B-16E-Instruct` → look for `llama4_example.py`
+   - User wants to quantize `Qwen/Qwen3-32B` → look for `qwen3_example.py`
+   - User wants to quantize `google/gemma-3-27b-it` → look for `gemma3_example.py`
+3. **If a matching example is found:**
+   - Download the raw file from GitHub (e.g. `https://raw.githubusercontent.com/vllm-project/llm-compressor/main/examples/quantization_w4a4_mxfp4/<filename>.py`)
+   - Replace the `MODEL_ID` value in the script with the user's MODEL_ID
+   - Adjust the `SAVE_DIR` if needed
+   - Use this as the quantization script — skip Step 5 template generation
+4. **If no matching example is found:**
+   - Proceed to Step 5 and generate the script from the template
+
+## Step 5 — Choose the quantization template and write the script (fallback)
+
+### QuantizationModifier (no calibration — standard path)
+
+```python
+from compressed_tensors.offload import dispatch_model
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+from llmcompressor import oneshot
+from llmcompressor.modifiers.quantization import QuantizationModifier
+
+MODEL_ID = "<MODEL_ID>"
+
+# Load model.
+model = AutoModelForCausalLM.from_pretrained(MODEL_ID)
+tokenizer = AutoTokenizer.from_pretrained(MODEL_ID)
+
+recipe = QuantizationModifier(
+    targets="Linear",
+    scheme="MXFP4",
+    ignore=["lm_head"],  # extend per model type — see Step 6
+)
+
+oneshot(model=model, recipe=recipe)
+
+print("========== SAMPLE GENERATION ==============")
+dispatch_model(model)
+input_ids = tokenizer("Hello my name is", return_tensors="pt").input_ids.to(model.device)
+output = model.generate(input_ids, max_new_tokens=100)
+print(tokenizer.decode(output[0]))
+print("==========================================")
+
+SAVE_DIR = MODEL_ID.rstrip("/").split("/")[-1] + "-MXFP4"
+model.save_pretrained(SAVE_DIR, save_compressed=True)
+tokenizer.save_pretrained(SAVE_DIR)
+```
+
+### GPTQModifier (with calibration — better accuracy)
+
+```python
+from compressed_tensors.offload import dispatch_model
+from datasets import load_dataset
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+from llmcompressor import oneshot
+from llmcompressor.modifiers.gptq import GPTQModifier
+
+MODEL_ID = "<MODEL_ID>"
+
+# Load model.
+model = AutoModelForCausalLM.from_pretrained(MODEL_ID)
+tokenizer = AutoTokenizer.from_pretrained(MODEL_ID)
+
+NUM_CALIBRATION_SAMPLES = 512
+MAX_SEQUENCE_LENGTH = 2048
+
+ds = load_dataset("HuggingFaceH4/ultrachat_200k", split=f"train_sft[:{NUM_CALIBRATION_SAMPLES}]")
+ds = ds.shuffle(seed=42)
+
+
+def preprocess(example):
+    return {"text": tokenizer.apply_chat_template(example["messages"], tokenize=False)}
+
+
+def tokenize(sample):
+    return tokenizer(
+        sample["text"],
+        padding=False,
+        max_length=MAX_SEQUENCE_LENGTH,
+        truncation=True,
+        add_special_tokens=False,
+    )
+
+
+ds = ds.map(preprocess)
+ds = ds.map(tokenize, remove_columns=ds.column_names)
+
+recipe = GPTQModifier(
+    targets="Linear",
+    scheme="MXFP4",
+    ignore=["lm_head"],  # extend per model type — see Step 6
+)
+
+oneshot(
+    model=model,
+    dataset=ds,
+    recipe=recipe,
+    max_seq_length=MAX_SEQUENCE_LENGTH,
+    num_calibration_samples=NUM_CALIBRATION_SAMPLES,
+)
+
+print("========== SAMPLE GENERATION ==============")
+dispatch_model(model)
+sample = tokenizer("Hello my name is", return_tensors="pt")
+sample = {key: value.to(model.device) for key, value in sample.items()}
+output = model.generate(**sample, max_new_tokens=100)
+print(tokenizer.decode(output[0]))
+print("==========================================")
+
+SAVE_DIR = MODEL_ID.rstrip("/").split("/")[-1] + "-MXFP4-GPTQ"
+model.save_pretrained(SAVE_DIR, save_compressed=True)
+tokenizer.save_pretrained(SAVE_DIR)
+```
+
+Place the file under `examples/quantization_w4a4_mxfp4/`.
+
+Name the file `{model_name_slug}_example.py` (e.g. `llama3_mxfp4.py`, `gemma4_mxfp4.py`).
+
+## Step 6 — Apply model-type adjustments
+
+### Dense models
+`ignore=["lm_head"]` is sufficient in most cases.
+
+### MoE models
+Add gate/router layers to `ignore`. For models that need a custom loading path, wrap the load in `load_context`:
+
+```python
+from llmcompressor.utils import load_context
+
+with load_context(SpecificModelClass):
+    model = SpecificModelClass.from_pretrained(MODEL_ID)
+```
+
+Common MoE ignore additions:
+- Qwen MoE: `"re:.*mlp.gate$"`, `"re:.*shared_expert_gate.*"`
+- Llama4 / Gemma4 MoE: `"re:.*router"`, `"Llama4TextAttention"`
+- General: `"re:.*mlp.router.*"`
+
+For MXFP4 on MoE, also consider skipping attention: `"re:.*self_attn"`.
+
+### Multimodal (vision / audio)
+- Use `AutoProcessor` instead of `AutoTokenizer`
+- Use the appropriate model class (e.g. `Gemma4ForConditionalGeneration`, `Llama4ForConditionalGeneration`) and wrap load in `load_context` if needed
+- Add to `ignore`:
+  - Vision: `"re:.*vision_tower.*"`, `"re:.*vision_model.*"`, `"re:.*multi_modal_projector.*"`
+  - Audio: `"re:.*audio_tower.*"`
+  - Embedding projections: `"re:.*embed.*"` (model-specific)
+
+## Step 7 — Run quantization with canhazgpu
+
+Launch the quantization script using `canhazgpu` with the required number of GPUs:
+
+```bash
+canhazgpu run --gpus <NUM_GPUS> -- python3 <script_name>.py
+```
+
+Wait for the quantization to complete. Monitor the output for errors.
+
+## Step 8 — Write and run vLLM verification test
+
+After quantization completes, create a `vllm_test.py` script to verify the compressed model loads and generates reasonable output:
+
+```python
+from vllm import LLM, SamplingParams
+
+if __name__ == '__main__':
+    model_name = "<SAVE_DIR>"
+    llm = LLM(model=model_name, tensor_parallel_size=<TENSOR_PARALLEL_SIZE>, trust_remote_code=True)
+
+    outputs = llm.generate(
+        ["Describe Large Language Models"],
+        SamplingParams(temperature=0.8, max_tokens=200)
+    )
+
+    print(outputs[0].outputs[0].text)
+```
+
+Run the vLLM test:
+```bash
+canhazgpu run --gpus <NUM_GPUS> -- python3 vllm_test.py
+```
+
+## Step 9 — Validate results
+
+After running `vllm_test.py`, check:
+1. The model loaded successfully without errors.
+2. The generated output is coherent and reasonable (not garbage/random tokens).
+
+If both conditions are met, the MXFP4 quantization is successful. Report the result to the user.
+
+If the output is garbled or the model fails to load, investigate:
+- Check if `ignore` layers need adjustment
+- Verify the correct algorithm was used (QuantizationModifier vs GPTQModifier)
+- If using GPTQModifier, try increasing calibration samples
+- Ensure tensor_parallel_size matches available GPUs
+
+## Step 10 — Upload to Hugging Face (optional)
+
+**Skip this step entirely if the user did not provide an HF repo name in Step 1.**
+
+If the user provided a repo name, upload the quantized model directory and a generated README.
+
+### 10a — Authenticate
+
+Pick up the HF token from the user's environment:
+```bash
+echo $HF_TOKEN
+```
+If `$HF_TOKEN` is not set, try `$HUGGING_FACE_HUB_TOKEN`. If neither is set, ask the user to provide one or run `huggingface-cli login`.
+
+### 10b — Generate README.md
+
+Create a `README.md` inside the `<SAVE_DIR>` directory. The README must be **specific to the model being quantized**. Use the template below and fill in all placeholders:
+
+- `<HF_REPO>` — the full repo name (e.g. `RedHatAI/Qwen3-8B-MXFP4`)
+- `<BASE_MODEL_ID>` — the original unquantized model (e.g. `Qwen/Qwen3-8B`)
+- `<MODEL_ARCH>` — the model's architecture class (e.g. `Qwen3ForCausalLM`, `LlamaForCausalLM`). Determine from the model's `config.json` `architectures` field.
+- `<ALGORITHM>` — the algorithm used (`QuantizationModifier` or `GPTQModifier`)
+- `<ALGORITHM_DESCRIPTION>` — algorithm-specific text:
+  - QuantizationModifier: "Weights and activations are quantized using the MXFP4 format with MX block scaling. No calibration data is required."
+  - GPTQModifier: "Weights and activations are quantized using the MXFP4 format with MX block scaling. GPTQ learned weight rounding with calibration data is used for improved accuracy."
+- `<TENSOR_PARALLEL_SIZE>` — number of GPUs for vLLM
+- `<QUANTIZATION_SCRIPT>` — the actual Python code used for quantization (from Step 4 or 5)
+- `<LANGUAGES>` — infer from the base model card; if unknown, use `en` only
+- `<LICENSE>` — infer from the base model card
+- `<TAGS>` — include the model family tag (e.g. `qwen`, `llama`, `gemma`), `mxfp4`, `fp4`, `vllm`, `conversational`, `text-generation-inference`
+- `<PIPELINE_TAG>` — typically `text-generation`
+
+**README template:**
+
+````markdown
+---
+language:
+<LANGUAGES_LIST>
+base_model:
+- <BASE_MODEL_ID>
+pipeline_tag: <PIPELINE_TAG>
+tags:
+<TAGS_LIST>
+license: <LICENSE>
+---
+
+## Model Overview
+- **Model Architecture:** <MODEL_ARCH>
+  - **Input:** Text
+  - **Output:** Text
+- **Model Optimizations:**
+  - **Activation quantization:** FP4
+  - **Weight quantization:** FP4
+- **Intended Use Cases:** Intended for commercial and research use. Similarly to the base model, this quantized version is intended for assistant-like chat.
+- **Out-of-scope:** Use in any manner that violates applicable laws or regulations (including trade compliance laws).
+- **Version:** 1.0
+- **Model Developers:** RedHat (Neural Magic)
+
+### Model Optimizations
+
+This model was obtained by quantizing activations and weights of [<BASE_MODEL_ID>](https://huggingface.co/<BASE_MODEL_ID>) to MXFP4 data type.
+This optimization reduces the number of bits used to represent weights and activations from 16 to 4, reducing GPU memory requirements (by approximately 75%) and increasing matrix-multiply compute throughput (by approximately 4x).
+Weight quantization also reduces disk size requirements by approximately 75%.
+
+Only weights and activations of the linear operators within transformers blocks are quantized.
+<ALGORITHM_DESCRIPTION>
+The [llm-compressor](https://github.com/vllm-project/llm-compressor) library is used for quantization.
+
+## Deployment
+
+This model can be deployed efficiently using the [vLLM](https://docs.vllm.ai/en/latest/) backend, as shown in the example below.
+
+```python
+from vllm import LLM, SamplingParams
+from transformers import AutoTokenizer
+
+model_id = "<HF_REPO>"
+number_gpus = <TENSOR_PARALLEL_SIZE>
+sampling_params = SamplingParams(temperature=0.6, top_p=0.95, top_k=20, min_p=0, max_tokens=256)
+
+tokenizer = AutoTokenizer.from_pretrained(model_id)
+messages = [{"role": "user", "content": "Give me a short introduction to large language model."}]
+prompts = tokenizer.apply_chat_template(messages, add_generation_prompt=True, tokenize=False)
+
+llm = LLM(model=model_id, tensor_parallel_size=number_gpus)
+outputs = llm.generate(prompts, sampling_params)
+generated_text = outputs[0].outputs[0].text
+print(generated_text)
+```
+
+## Creation
+
+<details>
+  <summary>Creation details</summary>
+
+  This model was created with [llm-compressor](https://github.com/vllm-project/llm-compressor) by running the code snippet below.
+
+  ```python
+  <QUANTIZATION_SCRIPT>
+  ```
+</details>
+````
+
+Adapt the template as needed:
+- For multimodal models, change Input/Output to reflect vision/audio capabilities
+- For MoE models, mention the MoE architecture in the overview
+- Include any model-family-specific tags or metadata from the base model card
+
+### 10c — Upload to Hugging Face
+
+Upload the entire quantized weight directory (including the generated README.md) to the HF repo:
+
+```bash
+huggingface-cli upload <HF_REPO> <SAVE_DIR> --token $HF_TOKEN
+```
+
+If the repo does not exist yet, create it first:
+```bash
+huggingface-cli repo create <REPO_NAME> --organization <ORG> --type model --token $HF_TOKEN
+```
+
+Verify the upload succeeded by checking the repo page.
+
+## Notes
+- With `QuantizationModifier`: `oneshot(model=model, recipe=recipe)` with no dataset is correct — no calibration data is needed.
+- With `GPTQModifier`: 512 samples at 2048 seq-len is a good default.
+- MXFP4 targets AMD MI300X for inference; quantization can run on any GPU.
+- `save_compressed=True` should be passed to `save_pretrained` for MXFP4 checkpoints.
+- The virtual environment name defaults to `compress_model` but can be customized if the user prefers.

--- a/ai_skills/compress_models/nvfp4/SKILL.md
+++ b/ai_skills/compress_models/nvfp4/SKILL.md
@@ -1,30 +1,32 @@
 ---
-name: fp8_compress
+name: nvfp4
 description: >
-  Generate a working FP8 quantization example script, set up an environment, install dependencies,
-  run quantization with canhazgpu, and verify the compressed model with vLLM.
-  Triggers on: "fp8", "FP8_DYNAMIC", "FP8_BLOCK", "MXFP8", "fp8 example", "quantize to fp8".
+  Generate a working NVFP4 quantization example script targeting H100/Blackwell, set up an environment,
+  install dependencies, run quantization with canhazgpu, and verify the compressed model with vLLM.
+  Triggers on: "nvfp4", "NVFP4", "nv fp4", "fp4 nvidia", "fp4 hopper", "fp4 blackwell", "h100 fp4".
 allowed-tools: [Read, Write, Glob, Shell, AskQuestion, WebFetch]
 ---
 
-# FP8 Quantization — End-to-End Workflow
+# NVFP4 Quantization — End-to-End Workflow
 
-Generate a working FP8 quantization script, create an isolated environment, run quantization on GPUs, and verify the result with vLLM.
+Generate a working NVFP4 quantization script, create an isolated environment, run quantization on GPUs, and verify the result with vLLM.
+
+Hardware requirement: H100 / Blackwell (sm90+) for inference. Quantization can run on any GPU.
 
 ## Step 1 — Gather information
 
 Ask the user (or infer from context) for:
 
-1. **MODEL_ID** — HuggingFace model ID (e.g. `meta-llama/Meta-Llama-3-8B-Instruct`)
-2. **Scheme variant** — choose one:
-   - `FP8_DYNAMIC` — weights fp8 per-channel, activations fp8 dynamic per-token. No calibration. Broadest hardware support (Ampere+). Recommended default.
-   - `FP8_BLOCK` — weights fp8 with 128x128 block scaling, activations dynamic. No calibration. Best throughput on Hopper/Blackwell.
-   - `MXFP8` — weights and activations in MX fp8 format. No calibration. AMD MI300X target.
+1. **MODEL_ID** — HuggingFace model ID (e.g. `meta-llama/Meta-Llama-3.1-8B-Instruct`)
+2. **Algorithm** — choose one:
+   - `QuantizationModifier` — simple PTQ, no weight optimization. Faster.
+   - `GPTQModifier` — learned weight rounding via GPTQ. Better accuracy, slower.
 3. **Model type** — dense, MoE, or multimodal (vision/audio)
-4. **Use `model_free_ptq`?** — yes if the model is very large (70B+) and should avoid full GPU load; otherwise use `oneshot`
-5. **Existing virtual environment** — Ask: "Do you have an existing virtual environment you'd like to use? If so, provide the path (e.g. `/data/user/myenv`). Otherwise a new one will be created."
-6. **Additional dependencies** — Ask: "Do you need any additional pip packages beyond `llmcompressor`, `vllm`, and `torchvision`?"
-7. **HF repo name (optional)** — Ask: "Do you want to upload the quantized model to a Hugging Face repo? If so, provide the repo name (e.g. `RedHatAI/Qwen3-8B-FP8-dynamic`). Leave blank to skip upload."
+4. **Existing virtual environment** — Ask: "Do you have an existing virtual environment you'd like to use? If so, provide the path (e.g. `/data/user/myenv`). Otherwise a new one will be created."
+5. **Additional dependencies** — Ask: "Do you need any additional pip packages beyond `llmcompressor`, `vllm`, and `torchvision`?"
+6. **HF repo name (optional)** — Ask: "Do you want to upload the quantized model to a Hugging Face repo? If so, provide the repo name (e.g. `RedHatAI/Qwen3-8B-NVFP4`). Leave blank to skip upload."
+
+NVFP4 always requires calibration data.
 
 ## Step 2 — Determine GPU requirements
 
@@ -39,7 +41,7 @@ Determine how many GPUs are needed based on model size:
 - **30B–70B parameters** — 4 GPUs
 - **70B+ parameters** — 8 GPUs
 
-If the required number of GPUs exceeds what is available, warn the user and ask how to proceed (e.g. use `model_free_ptq` instead, or wait for resources).
+If the required number of GPUs exceeds what is available, warn the user and ask how to proceed.
 
 Set `TENSOR_PARALLEL_SIZE` to the number of GPUs needed (used later for vLLM verification).
 
@@ -77,7 +79,7 @@ uv pip install <additional_packages>
 
 Before writing a script from scratch, check the upstream examples directory for an existing script that targets the same model architecture:
 
-**GitHub directory:** `https://github.com/vllm-project/llm-compressor/tree/main/examples/quantization_w8a8_fp8`
+**GitHub directory:** `https://github.com/vllm-project/llm-compressor/tree/main/examples/quantization_w4a4_fp4`
 
 1. Fetch the directory listing using `WebFetch` or browse the GitHub URL to see available example files.
 2. Identify if an example exists for the same model family / architecture as the user's MODEL_ID. For example:
@@ -85,7 +87,7 @@ Before writing a script from scratch, check the upstream examples directory for 
    - User wants to quantize `Qwen/Qwen3-32B` → look for `qwen3_example.py`
    - User wants to quantize `google/gemma-3-27b-it` → look for `gemma3_example.py`
 3. **If a matching example is found:**
-   - Download the raw file from GitHub (e.g. `https://raw.githubusercontent.com/vllm-project/llm-compressor/main/examples/quantization_w8a8_fp8/<filename>.py`)
+   - Download the raw file from GitHub (e.g. `https://raw.githubusercontent.com/vllm-project/llm-compressor/main/examples/quantization_w4a4_fp4/<filename>.py`)
    - Replace the `MODEL_ID` value in the script with the user's MODEL_ID
    - Adjust the `SAVE_DIR` if needed
    - Use this as the quantization script — skip Step 5 template generation
@@ -94,10 +96,10 @@ Before writing a script from scratch, check the upstream examples directory for 
 
 ## Step 5 — Choose the quantization template and write the script (fallback)
 
-### `oneshot` with `QuantizationModifier` (standard path)
+### QuantizationModifier (PTQ)
 
 ```python
-from compressed_tensors.offload import dispatch_model
+from datasets import load_dataset
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from llmcompressor import oneshot
@@ -109,81 +111,107 @@ MODEL_ID = "<MODEL_ID>"
 model = AutoModelForCausalLM.from_pretrained(MODEL_ID)
 tokenizer = AutoTokenizer.from_pretrained(MODEL_ID)
 
+NUM_CALIBRATION_SAMPLES = 256
+MAX_SEQUENCE_LENGTH = 2048
+
+ds = load_dataset("HuggingFaceH4/ultrachat_200k", split=f"train_sft[:{NUM_CALIBRATION_SAMPLES}]")
+ds = ds.shuffle(seed=42)
+
+
+def preprocess(example):
+    return {"text": tokenizer.apply_chat_template(example["messages"], tokenize=False)}
+
+
+def tokenize(sample):
+    return tokenizer(
+        sample["text"],
+        padding=False,
+        max_length=MAX_SEQUENCE_LENGTH,
+        truncation=True,
+        add_special_tokens=False,
+    )
+
+
+ds = ds.map(preprocess)
+ds = ds.map(tokenize, remove_columns=ds.column_names)
+
 recipe = QuantizationModifier(
     targets="Linear",
-    scheme="<SCHEME>",  # FP8_DYNAMIC | FP8_BLOCK | MXFP8
-    ignore=["lm_head"],  # extend per model type — see Step 6
+    scheme="NVFP4",
+    ignore=["lm_head", "re:.*embed_tokens$"],  # extend per model type — see Step 6
 )
 
-oneshot(model=model, recipe=recipe)
+oneshot(
+    model=model,
+    dataset=ds,
+    recipe=recipe,
+    max_seq_length=MAX_SEQUENCE_LENGTH,
+    num_calibration_samples=NUM_CALIBRATION_SAMPLES,
+)
 
-print("========== SAMPLE GENERATION ==============")
-dispatch_model(model)
-input_ids = tokenizer("Hello my name is", return_tensors="pt").input_ids.to(model.device)
-output = model.generate(input_ids, max_new_tokens=20)
-print(tokenizer.decode(output[0]))
-print("==========================================")
-
-SAVE_DIR = MODEL_ID.rstrip("/").split("/")[-1] + "-<SCHEME>"
+SAVE_DIR = MODEL_ID.rstrip("/").split("/")[-1] + "-NVFP4"
 model.save_pretrained(SAVE_DIR)
 tokenizer.save_pretrained(SAVE_DIR)
 ```
 
-### `model_free_ptq` (large models, avoids full GPU load)
+### GPTQModifier
+
+Replace only the recipe line:
 
 ```python
-from llmcompressor import model_free_ptq
+from llmcompressor.modifiers.gptq import GPTQModifier
 
-MODEL_ID = "<MODEL_ID>"
-SAVE_DIR = MODEL_ID.rstrip("/").split("/")[-1] + "-<SCHEME>"
-
-model_free_ptq(
-    model_stub=MODEL_ID,
-    save_directory=SAVE_DIR,
-    scheme="<SCHEME>",  # FP8_DYNAMIC | FP8_BLOCK
-    ignore=[
-        "model.embed_tokens",
-        "lm_head",
-        # extend per model type — see Step 6
-    ],
-    max_workers=15,
-    device="cuda:0",
+recipe = GPTQModifier(
+    targets="Linear",
+    scheme="NVFP4",
+    ignore=["lm_head", "re:.*embed_tokens$"],  # extend per model type — see Step 6
 )
 ```
 
-Place the file in the appropriate directory under `examples/`:
-- `quantization_w8a8_fp8/` for FP8_DYNAMIC or FP8_BLOCK (oneshot path)
-- `quantization_w8a8_mxfp8/` for MXFP8
-- `model_free_ptq/` when using `model_free_ptq()`
+Everything else (data loading, `oneshot` call, save) is identical to the `QuantizationModifier` template.
 
-Name the file `{model_name_slug}_example.py` (e.g. `llama3_example.py`, `gemma4_example.py`).
+Place the file in the appropriate directory under `examples/quantization_w4a4_fp4/`.
+
+Name the file `{model_name_slug}_example.py` (e.g. `llama3_example.py`, `qwen3_5_example.py`).
 
 ## Step 6 — Apply model-type adjustments
 
 ### Dense models
-`ignore=["lm_head"]` is sufficient in most cases.
+`ignore=["lm_head", "re:.*embed_tokens$"]`
 
 ### MoE models
-Add gate/router layers to `ignore`. For models that require a custom loading path, wrap the load in `load_context`:
+Add gate/router layers to `ignore`. For models that need a custom loading path, wrap the load in `load_context`:
+
 ```python
 from llmcompressor.utils import load_context
 
 with load_context(SpecificModelClass):
     model = SpecificModelClass.from_pretrained(MODEL_ID)
 ```
-Common MoE ignore additions:
-- Qwen MoE: `"re:.*mlp.gate$"`, `"re:.*shared_expert_gate.*"`
-- Llama4 / Gemma4 MoE: `"re:.*router"`, `"Llama4TextAttention"`
 
-For FP8_BLOCK on MoE, also skip attention: `"re:.*self_attn"`.
+Common MoE ignore additions:
+- Qwen MoE: `"re:.*mlp.gate$"`, `"re:.*shared_expert_gate.*"`, `"re:.*linear_attn.*"`
+- Llama4: `"re:.*router"`, `"re:.*self_attn"`, `"Llama4TextAttention"`
+- General: `"re:.*mlp.router.*"`, `"re:.*self_attn.*"`
+
+For large MoE models, calibrate one expert block at a time:
+```python
+oneshot(..., sequential_targets=["Llama4TextMLP"])
+```
+
+To calibrate all experts (not just sampled routed ones):
+```python
+oneshot(..., moe_calibrate_all_experts=True)
+```
 
 ### Multimodal (vision / audio)
 - Use `AutoProcessor` instead of `AutoTokenizer`
-- Use the appropriate model class (e.g. `Gemma4ForConditionalGeneration`, `Llama4ForConditionalGeneration`) and wrap load in `load_context` if needed
+- Use the model-specific class and `load_context` if needed
 - Add to `ignore`:
   - Vision: `"re:.*vision_tower.*"`, `"re:.*vision_model.*"`, `"re:.*multi_modal_projector.*"`
   - Audio: `"re:.*audio_tower.*"`
-  - Embedding projections: `"re:.*embed.*"` (model-specific)
+  - Embedding projections: `"re:.*embed_vision.*"`, `"re:.*embed_audio.*"`
+- Preprocessing must use `processor.apply_chat_template` with `return_dict=True`; pass a `data_collator` to `oneshot`
 
 ## Step 7 — Run quantization with canhazgpu
 
@@ -225,11 +253,11 @@ After running `vllm_test.py`, check:
 1. The model loaded successfully without errors.
 2. The generated output is coherent and reasonable (not garbage/random tokens).
 
-If both conditions are met, the FP8 quantization is successful. Report the result to the user.
+If both conditions are met, the NVFP4 quantization is successful. Report the result to the user.
 
 If the output is garbled or the model fails to load, investigate:
 - Check if `ignore` layers need adjustment
-- Verify the correct scheme was used for the hardware
+- Verify the model is being run on H100/Blackwell (sm90+ required for NVFP4 inference)
 - Ensure tensor_parallel_size matches available GPUs
 
 ## Step 10 — Upload to Hugging Face (optional)
@@ -250,19 +278,15 @@ If `$HF_TOKEN` is not set, try `$HUGGING_FACE_HUB_TOKEN`. If neither is set, ask
 
 Create a `README.md` inside the `<SAVE_DIR>` directory. The README must be **specific to the model being quantized**. Use the template below and fill in all placeholders:
 
-- `<HF_REPO>` — the full repo name (e.g. `RedHatAI/Qwen3-8B-FP8-dynamic`)
+- `<HF_REPO>` — the full repo name (e.g. `RedHatAI/Qwen3-8B-NVFP4`)
 - `<BASE_MODEL_ID>` — the original unquantized model (e.g. `Qwen/Qwen3-8B`)
 - `<MODEL_ARCH>` — the model's architecture class (e.g. `Qwen3ForCausalLM`, `LlamaForCausalLM`). Determine from the model's `config.json` `architectures` field.
-- `<SCHEME>` — the quantization scheme used (`FP8_DYNAMIC`, `FP8_BLOCK`, or `MXFP8`)
-- `<SCHEME_DESCRIPTION>` — scheme-specific text:
-  - FP8_DYNAMIC: "Weights are quantized with a symmetric static per-channel scheme, whereas activations are quantized with a symmetric dynamic per-token scheme."
-  - FP8_BLOCK: "Weights are quantized with 128x128 block scaling, and activations are quantized dynamically."
-  - MXFP8: "Weights and activations are quantized using the MX FP8 format."
+- `<ALGORITHM>` — either `QuantizationModifier` or `GPTQModifier`
 - `<TENSOR_PARALLEL_SIZE>` — number of GPUs for vLLM
 - `<QUANTIZATION_SCRIPT>` — the actual Python code used for quantization (from Step 4 or 5)
 - `<LANGUAGES>` — infer from the base model card; if unknown, use `en` only
 - `<LICENSE>` — infer from the base model card
-- `<TAGS>` — include the model family tag (e.g. `qwen`, `llama`, `gemma`), `fp8`, `vllm`, `conversational`, `text-generation-inference`
+- `<TAGS>` — include the model family tag (e.g. `qwen`, `llama`, `gemma`), `nvfp4`, `fp4`, `vllm`, `conversational`, `text-generation-inference`
 - `<PIPELINE_TAG>` — typically `text-generation`
 
 **README template:**
@@ -284,8 +308,8 @@ license: <LICENSE>
   - **Input:** Text
   - **Output:** Text
 - **Model Optimizations:**
-  - **Activation quantization:** FP8
-  - **Weight quantization:** FP8
+  - **Activation quantization:** FP4
+  - **Weight quantization:** FP4
 - **Intended Use Cases:** Intended for commercial and research use. Similarly to the base model, this quantized version is intended for assistant-like chat.
 - **Out-of-scope:** Use in any manner that violates applicable laws or regulations (including trade compliance laws).
 - **Version:** 1.0
@@ -293,13 +317,14 @@ license: <LICENSE>
 
 ### Model Optimizations
 
-This model was obtained by quantizing activations and weights of [<BASE_MODEL_ID>](https://huggingface.co/<BASE_MODEL_ID>) to FP8 data type.
-This optimization reduces the number of bits used to represent weights and activations from 16 to 8, reducing GPU memory requirements (by approximately 50%) and increasing matrix-multiply compute throughput (by approximately 2x).
-Weight quantization also reduces disk size requirements by approximately 50%.
+This model was obtained by quantizing weights and activations of [<BASE_MODEL_ID>](https://huggingface.co/<BASE_MODEL_ID>) to NVFP4 data type.
+This optimization reduces the number of bits used to represent weights from 16 to 4, significantly reducing GPU memory requirements (by approximately 75%) and increasing inference throughput.
 
 Only weights and activations of the linear operators within transformers blocks are quantized.
-<SCHEME_DESCRIPTION>
+Quantization is performed using the NVFP4 scheme, which targets NVIDIA H100 and Blackwell (sm90+) GPUs.
 The [llm-compressor](https://github.com/vllm-project/llm-compressor) library is used for quantization.
+
+**Hardware requirement:** H100 / Blackwell (sm90+) for inference.
 
 ## Deployment
 
@@ -357,9 +382,8 @@ huggingface-cli repo create <REPO_NAME> --organization <ORG> --type model --toke
 Verify the upload succeeded by checking the repo page.
 
 ## Notes
-- `FP8_DYNAMIC` is the recommended starting point — no calibration required, broad hardware support.
-- `FP8_BLOCK` is preferred for Hopper/Blackwell throughput.
-- `MXFP8` targets AMD MI300X.
-- Neither scheme requires a calibration dataset; `oneshot(model=model, recipe=recipe)` with no `dataset` argument is correct.
-- `save_compressed=True` is optional — the checkpoint saves in compressed-tensors format either way. Omit unless explicitly requested.
+- 256 calibration samples at 2048 sequence length is a good default; increase samples if accuracy drops.
+- NVFP4 always requires calibration data — unlike FP8, you cannot skip the dataset.
+- MTP (multi-token prediction) layers in some Qwen models are excluded from the standard model class. Save them separately after quantization using `save_mtp_tensors_to_checkpoint` from `compressed_tensors`.
+- `save_compressed=True` is not required — NVFP4 checkpoints save correctly without it, but it can be added.
 - The virtual environment name defaults to `compress_model` but can be customized if the user prefers.


### PR DESCRIPTION
Skill which does the following:

1. Accepts the model ID and quantization mode as input from the user
2. Creates and activates a virtual environment, or reuses one if provided
3. Installs required dependencies (vLLM, llm-compressor)
4. Scans the llm-compressor GitHub repo for a relevant example
5. Generates the llm-compressor quantization script based on a matching example if found, or generates from existing ones
6. Detects the number of available GPUs on the node using canhazgpu
7. Quantizes the model to FP8 or NVFP4, per the user's request
8. Runs a smoke test in vLLM to confirm the quantized model loads correctly. Automatically adjusts the TP size
9. Checks if the vLLM output is reasonable
10. Uploads the quantized checkpoint to the specified HF repo or skips if not provided
11. Generates a README file for that repo