### PR TITLE
Update create-model-card-compression skill: BFCLv4 support, score scripts, template improvements

### DIFF
--- a/ai_skills/huggingface/create-model-card-compression/SKILL.md
+++ b/ai_skills/huggingface/create-model-card-compression/SKILL.md
@@ -54,27 +54,31 @@ These are the **defaults for the final README** unless the user asks otherwise:
 
 ### Deployment (vLLM)
 
-- **Simple** primary example: `vllm serve RedHatAI/<model>…` with **model-specific flags taken from the base model’s HuggingFace README** (e.g. `--reasoning-parser`, `--tool-call-parser`, `--enable-auto-tool-choice`, `--speculative-config` for MTP, `--language-model-only`, `--max-model-len`) **merged into the command** when that matches upstream guidance.
-- Do **not** prescribe **tensor parallel size** or long hardware tuning prose; a single line that users can adapt is enough.
+- **Simple** primary example: `vllm serve RedHatAI/<model>…` with **model-specific flags taken from the base model’s HuggingFace README and the [vLLM recipes page](https://recipes.vllm.ai)** (`recipes.vllm.ai/<org>/<model>`) (e.g. `--reasoning-parser`, `--tool-call-parser`, `--enable-auto-tool-choice`, `--speculative-config` for MTP, `--language-model-only`, `--max-model-len`, `--async-scheduling`, `--limit-mm-per-prompt`) **merged into the command** when that matches upstream guidance. Prefer the vLLM recipes page — it is often more complete than the base model’s HF README.
+- Do **not** prescribe **tensor parallel size** unless the unquantized model’s card or the vLLM recipes page specifies it. A single line that users can adapt is enough.
+- Include `--chat-template <path>` in vLLM serve commands when a custom chat template was used (e.g. for tool calling or thinking mode). Use the filename from the vLLM recipes page (e.g. `examples/tool_chat_template_gemma4.jinja`) — do not hard-code local machine paths.
 
 ### Evaluation (intro paragraph)
 
-- **Brief**: name the **benchmarks** and the libraries — **[lm-evaluation-harness](https://github.com/EleutherAI/lm-evaluation-harness)**, **[lighteval](https://github.com/huggingface/lighteval)**, and serving with **vLLM** (OpenAI-compatible API).
-- Do **not** mention **forks** of lm-eval or lighteval unless the user explicitly asks; treat upstream as the reference.
+- **Brief**: name the **benchmarks** and the libraries used — **[lm-evaluation-harness](https://github.com/neuralmagic/lm-evaluation-harness)**, **[lighteval](https://github.com/neuralmagic/lighteval)**, and **BFCL** (when tool-calling results are available) — and serving with **vLLM** (OpenAI-compatible API). Only mention harnesses and benchmarks for which results are present.
 
 ### Accuracy table
 
 - When **baseline (e.g. BF16) JSON** exists: include baseline and quantized columns plus **Recovery** (quantized score ÷ baseline score, as a percentage). Omit baseline/Recovery if no baseline.
 - Prefer **HTML `<table>`** with **`rowspan`** on **Category** so each category label appears once per group.
 - **IFEval**: default to **two benchmark rows** (e.g. prompt-level strict and instruction-level strict) with **Instruction following** `rowspan` on the category column — unless the user prefers a grouped layout.
+- **Benchmark categories depend on the evaluation protocol**: GSM8K Platinum and MMLU-Pro belong under **Reasoning** when evaluated 0-shot (with or without thinking). They belong under **Instruction Following** only when evaluated 5-shot. IFEval always belongs under **Instruction Following** regardless of shot count.
 - Omit a separate **metric** column if the user wants a cleaner table (benchmark names can carry the distinction).
+- **Thinking mode**: if results are available for both thinking and non-thinking modes, present two separate tables under `#### Without thinking` and `#### With thinking` subsections, each with its own BF16 baseline column. If only one set is available, present a single table without subsection headers.
+- **BFCLv4**: when tool-calling results are available, add a **Tool Calling** category at the bottom of the table (or the "with thinking" table if results are split). Include four rows: Overall, Single Turn, Multi-Turn, Agentic. Show scores as percentages (e.g. `68.31%`). Omit when not available or when the model has no tool-calling support.
 
 ### Reproduction
 
 - Show the **simplest** representative **lm-eval** and **lighteval** commands (no seed loops in the snippet unless the user wants them).
 - Summarize **repetitions per benchmark in prose** (e.g. 3 runs for most tasks, 8 for AIME): state that each task is run **N times** with seeds.
-- Include the full **`litellm_config.yaml`** content used for lighteval (`provider`, `hosted_vllm` model id, `base_url`, timeouts, `concurrent_requests`, `max_model_length`, `generation_parameters` aligned with the model card / base model sampling guidance).
+- Include the full **`litellm_config.yaml`** content used for lighteval (`provider`, `hosted_vllm` model id, `base_url`, timeouts, `concurrent_requests`, `generation_parameters` aligned with the model card / base model sampling guidance). If actual config files exist in the run directory, copy them exactly — do not invent fields that were not present (e.g. `max_model_length` is optional and should only be included if it appears in the actual config).
 - Keep **sampling / adapter details** out of the Evaluation intro; they belong here under Reproduction.
+- When **BFCLv4 results** are included: add a BFCLv4 section inside the `<details>` block showing the model registration steps (`model_config.py` entry + `supported_models.py`) and the `bfcl generate` / `bfcl evaluate` commands. See `evaluations.md` for the full protocol.
 
 ## Phase 1: Gather Model Information
 
@@ -89,6 +93,7 @@ These are the **defaults for the final README** unless the user asks otherwise:
 
 3. **Read `config.json`** from the model path:
    - Extract `model_type`, `_name_or_path`, and architecture details.
+   - The **Model Architecture** line in the card uses `config.json`'s `architectures[0]` value (the class name, e.g. `LlamaForCausalLM`, `Gemma4ForConditionalGeneration`) — not `_name_or_path` or the HuggingFace model ID.
    - For a HuggingFace model ID, fetch via the Hub API or `huggingface_hub` (raw `huggingface.co/.../raw/main/config.json` may return **401** for gated or token-only repos — use authenticated download or a workspace cache directory if needed).
 
 4. **Read `recipe.yaml`** from the model path to determine the quantization
@@ -116,20 +121,30 @@ before continuing. Example:
 
 ## Phase 2: Collect Evaluation Results
 
-7. **Search for evaluation result JSON files** in the model directory (and
-   subdirectories). Look for:
+7. **Search for evaluation result JSON files** in the model directory, any user-specified runs directory, and subdirectories. Look for:
+   - **every_eval_ever output** (highest priority): JSON files inside an `every_eval_ever/`
+     folder at the root of the model directory. If this folder is present, use its
+     JSON files as the authoritative source for all results tables. These files take
+     precedence over any other result files found.
+   - **Aggregated result JSONs in run directories**: files with `schema_version` at the top level (produced by the evaluation harness aggregation step). These are the authoritative per-benchmark scores. Prefer these over any narrative `summary.md` files — `summary.md` is human-written and may contain errors.
    - **lm-eval output**: JSON files containing a top-level `"results"` key with
      task names mapping to metric dictionaries.
    - **lighteval output**: JSON files inside output directories with task metrics.
    - Common patterns: `results*.json`, `**/results.json`
+   - **BFCLv4 scores**: check `score/data_overall.csv` and `score/quantized/data_overall.csv` relative to the BFCL repo root (the path may vary). The Overall score is typically pre-computed in the CSV; sub-scores (Single Turn, Multi-Turn, Agentic) may require reading per-category JSON files under `score/` and applying the weighting formula in `evaluations.md`. If no CSV is found automatically, prompt the user for the path to the BFCL score directory.
    - Baseline runs may use parallel naming (e.g. `*_bf16_*` vs `*_fp8_*`); parse and match the same metrics.
    - Normalize benchmark/task names before matching (lowercase, trim whitespace, collapse repeated separators, and map common aliases such as `ifeval`/`IFEval`).
 
 8. **If results are found**:
-   - Parse each file, extracting benchmark name and metric scores.
-   - Group by benchmark name.
-   - If the same benchmark appears multiple times (different seeds/runs),
-     **average the scores** across repetitions and report the average.
+   - Run `compute_averages.py` (located in the same folder as this `SKILL.md`) on all
+     found result files and directories. For BFCL CSV files, also pass `--bfcl-model`
+     with the quantized model name. Capture the JSON output.
+   - **Always** use this script — do not hand-parse or hand-average result files. The
+     script handles all supported formats (summary_data.json, lm-eval JSON, BFCL CSV)
+     and outputs a consistent `{task:metric -> {mean, n}}` structure with scores in
+     percentage form.
+   - **Do not trust `summary.md`** or other narrative files as the source of scores —
+     always derive from the actual JSON/CSV files via the script.
    - Present the parsed results to the user for confirmation.
 
 9. **If no results are found**: tell the user and ask:
@@ -139,9 +154,16 @@ before continuing. Example:
 
 10. **Ask for unquantized (baseline) results**: request a path to the baseline
    model's evaluation results. If provided:
-   - Load and match benchmarks by normalized benchmark and metric names (case-insensitive).
-   - Compute Recovery = (quantized_score / baseline_score) * 100 for each metric.
-   - If baseline score is `0`, missing, or non-numeric, set Recovery to `N/A` for that row and continue.
+   - Run `compute_averages.py` on the baseline result files (same as step 8) to
+     produce a baseline averages JSON. For BFCL, pass `--bfcl-model` with the
+     **unquantized** model name.
+   - Run `compute_recovery.py` (located in the same folder as this `SKILL.md`) with
+     the baseline averages JSON and the quantized model averages JSON from step 8.
+     Capture the JSON output.
+   - **Always** use these scripts — do not hand-compute recovery. The script produces
+     a consistent `{task:metric -> {baseline, quantized, recovery_pct}}` structure.
+   - If baseline score is `0` or missing for a metric, the script sets `recovery_pct`
+     to `null`; show `N/A` in the table for that row.
    - If not available, omit the Recovery column (and baseline column) from the table.
 
 ## Phase 3: Prompt for Missing Information
@@ -163,7 +185,7 @@ before continuing. Example:
 
 ## Phase 4: Generate Draft
 
-12. **Read the model card template** from `template.md` located in the **same folder as this `SKILL.md`**. This template contains the full structure with placeholders and guidance comments. **Adapt** the template to the **Published card conventions** above when they conflict (overview brevity, deployment simplicity, no fork language, etc.). Try to keep to the template as closely as possible.
+12. **Read the model card template** from `template.md` located in the **same folder as this `SKILL.md`**. This template contains the full structure with placeholders and guidance comments. **Adapt** the template to the **Published card conventions** above when they conflict (overview brevity, deployment simplicity, etc.). Try to keep to the template as closely as possible.
 
 13. **Read the evaluation protocol** from
     `evaluations.md` located in the **same folder as this `SKILL.md`** (if present). If the file is missing, continue with best-practice defaults from this skill. Use it to choose harnesses, task names,
@@ -213,6 +235,7 @@ before continuing. Example:
       `RedHatAI/<model_name>` on HuggingFace.
     - If the model path is a **HuggingFace model ID**: ask the user if they want
       to upload just the README.md to the existing repo.
+    - **If `every_eval_ever/` JSON files were used**: also upload those files to `every_eval_ever/` inside the HuggingFace repo. Upload **only the top-level aggregated JSON files (one per benchmark)** — do not upload per-seed subdirectories, raw lm-eval output files, or lighteval detail parquet files. Do this as part of the same upload action and confirm with the user before proceeding.
     - **Only proceed after the user explicitly confirms.**
     - If no automated upload path is available, explicitly tell the user the card was generated locally and provide manual upload commands/options.
 

--- a/ai_skills/huggingface/create-model-card-compression/compute_averages.py
+++ b/ai_skills/huggingface/create-model-card-compression/compute_averages.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+"""
+Compute averaged benchmark scores from evaluation result files.
+
+Supported input formats:
+  - summary_data.json  Internal aggregated format (has run_id + results with mean/values/count).
+                       Scores are already averaged across seeds; mean is used directly.
+  - lm-eval JSON       Top-level "results" key, values are {metric: float} dicts.
+                       When multiple files cover the same task, scores are averaged.
+  - BFCL CSV          data_overall.csv with Overall/Non-Live/Multi-Turn/... columns.
+                       Agentic is computed as avg(Web Search, Memory) when not present.
+
+Usage:
+  # Single summary_data.json (handles all tasks in one file)
+  python compute_averages.py run_dir/summary_data.json
+
+  # Directory — searched recursively for summary_data.json and results*.json
+  python compute_averages.py ./run_dir/
+
+  # Multiple lm-eval JSON files (one per seed) for the same task
+  python compute_averages.py seed1.json seed2.json seed3.json
+
+  # BFCL CSV — specify model name substring to extract
+  python compute_averages.py score/data_overall.csv --bfcl-model "gemma-4-26B-A4B-it-FP8"
+
+  # Write output to file
+  python compute_averages.py run_dir/ --output quantized_scores.json
+
+Output JSON (scores in percentage, 0–100):
+  {
+    "task:metric": {"mean": 85.93, "n": 3},
+    ...
+  }
+"""
+
+import argparse
+import csv
+import json
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+
+# ── Format detection ──────────────────────────────────────────────────────────
+
+def detect_json_format(data: dict) -> str:
+    """Return 'summary_data', 'lm_eval', or 'unknown'."""
+    if "run_id" in data and isinstance(data.get("results"), dict):
+        # Check that values look like {metric: {mean, values, count}}
+        for task_metrics in data["results"].values():
+            if not isinstance(task_metrics, dict):
+                break
+            for stats in task_metrics.values():
+                if isinstance(stats, dict) and "mean" in stats:
+                    return "summary_data"
+            break
+    if isinstance(data.get("results"), dict):
+        for task_val in data["results"].values():
+            if isinstance(task_val, dict):
+                for v in task_val.values():
+                    if isinstance(v, (int, float)):
+                        return "lm_eval"
+            break
+    return "unknown"
+
+
+# ── Parsers ───────────────────────────────────────────────────────────────────
+
+def parse_summary_data(data: dict) -> dict:
+    """
+    Parse internal summary_data.json.
+    Returns {task:metric -> (mean_fraction, count)}.
+    Already averaged — uses stored mean directly.
+    """
+    scores = {}
+    for task, metrics in data.get("results", {}).items():
+        for metric, stats in metrics.items():
+            if metric.endswith("_stderr") or not isinstance(stats, dict):
+                continue
+            if "mean" in stats:
+                scores[f"{task}:{metric}"] = (stats["mean"], stats.get("count", 1))
+    return scores
+
+
+def parse_lm_eval(data: dict) -> dict:
+    """
+    Parse lm-eval output JSON.
+    Returns {task:metric -> float} on 0–1 scale.
+    """
+    scores = {}
+    for task, metrics in data.get("results", {}).items():
+        for metric, value in metrics.items():
+            if metric == "alias":
+                continue
+            if metric.endswith("_stderr") or not isinstance(value, (int, float)):
+                continue
+            scores[f"{task}:{metric}"] = value
+    return scores
+
+
+def parse_bfcl_csv(filepath: Path, model_filter: str) -> dict:
+    """
+    Parse a BFCL data_overall.csv.
+    Returns {bfcl:ColumnName -> float} on 0–100 scale for the matched model.
+    Agentic = avg(Web Search, Memory) when not already present.
+    """
+    matched = {}
+    with open(filepath, newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            model = (row.get("Model") or row.get("model") or "").strip()
+            if model_filter.lower() not in model.lower():
+                continue
+            raw = {}
+            for col, val in row.items():
+                col = col.strip()
+                if col.lower() in ("model", "rank", "notes", ""):
+                    continue
+                try:
+                    raw[col] = float(val)
+                except (ValueError, TypeError):
+                    pass
+            if "Agentic" not in raw:
+                web = raw.get("Web Search")
+                mem = raw.get("Memory")
+                if web is not None and mem is not None:
+                    raw["Agentic"] = (web + mem) / 2.0
+            matched = {f"bfcl:{k}": v for k, v in raw.items()}
+            break  # use first match
+
+    if not matched:
+        print(
+            f"Warning: no model matching '{model_filter}' found in {filepath}",
+            file=sys.stderr,
+        )
+    return matched
+
+
+# ── File discovery ─────────────────────────────────────────────────────────────
+
+def find_result_files(path: Path) -> list:
+    """Find summary_data.json and results*.json files under path."""
+    if path.is_file():
+        return [path]
+    files = []
+    for f in sorted(path.rglob("*.json")):
+        if f.name == "summary_data.json" or f.name.startswith("results"):
+            files.append(f)
+    return files
+
+
+# ── Main ───────────────────────────────────────────────────────────────────────
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Compute averaged benchmark scores from evaluation result files.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("paths", nargs="+", help="Result files, directories, or BFCL CSVs")
+    parser.add_argument("--output", "-o", default="-", help="Output JSON file (default: stdout)")
+    parser.add_argument(
+        "--bfcl-model",
+        metavar="MODEL",
+        default="",
+        help="Model name substring to match in BFCL CSV (case-insensitive)",
+    )
+    args = parser.parse_args()
+
+    # Scores from summary_data (already averaged): {key -> (mean_01, count)}
+    final = {}
+    # Scores from individual lm-eval files: {key -> [raw_01, ...]}
+    accumulated = defaultdict(list)
+    # BFCL scores (already 0-100): {key -> float}
+    bfcl_scores = {}
+
+    for path_str in args.paths:
+        path = Path(path_str)
+        if not path.exists():
+            print(f"Warning: {path} does not exist, skipping", file=sys.stderr)
+            continue
+
+        # BFCL CSV
+        if path.suffix == ".csv":
+            if not args.bfcl_model:
+                print(
+                    f"BFCL CSV provided but --bfcl-model not specified; skipping {path}",
+                    file=sys.stderr,
+                )
+                continue
+            bfcl_scores.update(parse_bfcl_csv(path, args.bfcl_model))
+            continue
+
+        result_files = find_result_files(path)
+        if not result_files:
+            print(f"Warning: no result files found under {path}", file=sys.stderr)
+            continue
+
+        for filepath in result_files:
+            try:
+                with open(filepath, encoding="utf-8") as f:
+                    data = json.load(f)
+            except (json.JSONDecodeError, OSError) as e:
+                print(f"Warning: could not read {filepath}: {e}", file=sys.stderr)
+                continue
+
+            fmt = detect_json_format(data)
+            if fmt == "summary_data":
+                for key, (mean_01, count) in parse_summary_data(data).items():
+                    if key in final:
+                        print(
+                            f"Warning: duplicate summary_data entry for '{key}', keeping first",
+                            file=sys.stderr,
+                        )
+                    else:
+                        final[key] = (mean_01, count)
+            elif fmt == "lm_eval":
+                for key, val in parse_lm_eval(data).items():
+                    accumulated[key].append(val)
+            else:
+                print(f"Warning: unknown format in {filepath}, skipping", file=sys.stderr)
+
+    # Build output (all scores in percentage, 0–100)
+    output = {}
+
+    for key, (mean_01, n) in sorted(final.items()):
+        output[key] = {"mean": round(mean_01 * 100, 2), "n": n}
+
+    for key, values in sorted(accumulated.items()):
+        if key in output:
+            continue  # summary_data takes precedence
+        avg = sum(values) / len(values)
+        output[key] = {
+            "mean": round(avg * 100, 2),
+            "n": len(values),
+            "values": [round(v * 100, 2) for v in values],
+        }
+
+    for key, val in sorted(bfcl_scores.items()):
+        output[key] = {"mean": round(val, 2), "n": 1}
+
+    text = json.dumps(output, indent=2)
+    if args.output == "-":
+        print(text)
+    else:
+        Path(args.output).write_text(text, encoding="utf-8")
+        print(f"Averages written to {args.output}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/ai_skills/huggingface/create-model-card-compression/compute_recovery.py
+++ b/ai_skills/huggingface/create-model-card-compression/compute_recovery.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""
+Compute recovery percentages between baseline and quantized model scores.
+
+Both inputs must be JSON files produced by compute_averages.py:
+  {"task:metric": {"mean": <float_pct_0_to_100>, "n": <int>}, ...}
+
+Usage:
+  python compute_recovery.py baseline_scores.json quantized_scores.json
+  python compute_recovery.py baseline_scores.json quantized_scores.json --output recovery.json
+
+Output JSON:
+  {
+    "task:metric": {
+      "baseline": 85.93,
+      "quantized": 84.10,
+      "recovery_pct": 97.87
+    },
+    ...
+  }
+
+Notes:
+  - Keys present only in the quantized file are included with baseline=null, recovery_pct=null.
+  - Keys present only in the baseline file are included with quantized=null, recovery_pct=null.
+  - If baseline is 0 or null, recovery_pct is set to null (shown as N/A in the model card table).
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def load_averages(path: Path) -> dict:
+    try:
+        with open(path, encoding="utf-8") as f:
+            data = json.load(f)
+    except (json.JSONDecodeError, OSError) as e:
+        print(f"Error reading {path}: {e}", file=sys.stderr)
+        sys.exit(1)
+    return data
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Compute recovery percentages from compute_averages.py output.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("baseline", help="Baseline averages JSON (from compute_averages.py)")
+    parser.add_argument("quantized", help="Quantized averages JSON (from compute_averages.py)")
+    parser.add_argument("--output", "-o", default="-", help="Output JSON file (default: stdout)")
+    args = parser.parse_args()
+
+    baseline = load_averages(Path(args.baseline))
+    quantized = load_averages(Path(args.quantized))
+
+    all_keys = sorted(set(baseline) | set(quantized))
+    output = {}
+
+    for key in all_keys:
+        b_entry = baseline.get(key)
+        q_entry = quantized.get(key)
+
+        b_mean = b_entry["mean"] if b_entry else None
+        q_mean = q_entry["mean"] if q_entry else None
+
+        if b_mean is not None and q_mean is not None and b_mean != 0:
+            recovery = round(q_mean / b_mean * 100, 2)
+        else:
+            recovery = None
+
+        output[key] = {
+            "baseline": b_mean,
+            "quantized": q_mean,
+            "recovery_pct": recovery,
+        }
+
+    text = json.dumps(output, indent=2)
+    if args.output == "-":
+        print(text)
+    else:
+        Path(args.output).write_text(text, encoding="utf-8")
+        print(f"Recovery written to {args.output}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/ai_skills/huggingface/create-model-card-compression/evaluations.md
+++ b/ai_skills/huggingface/create-model-card-compression/evaluations.md
@@ -1,41 +1,39 @@
-# General instructions
-
 # Evaluations using vLLM server
 
-# Start vLLM server
+This document is a catalogue of known benchmarks and their evaluation protocols.
+The skill should search for and report whatever benchmarks are available — only
+include results that were actually run. Do not skip or error if a benchmark is missing.
 
-Start vLLM server using the configurations recommended by the model provider:
+---
+
+## Serving the model
+
+Start the vLLM server using the configuration recommended by the model provider.
+The vLLM recipes page (`recipes.vllm.ai/<org>/<model>`) is the primary reference for
+model-specific flags such as `--tool-call-parser`, `--reasoning-parser`,
+`--tokenizer-mode`, and `--load-format`.
 
 ```
 vllm serve <model_name> ...
 ```
 
-Please note arguments such as
+---
 
-- load-format  
-- config-format  
-- tokenizer-mode  
-- tool-call-parser  
-- reasoning-parser
+## lighteval
 
-# lighteval
+**Note:** use the neuralmagic fork: https://github.com/neuralmagic/lighteval
 
-**Note**: we’ve identified a couple of bugs in the upstream lighteval library, and until our bug fixes are merged into main (we’ll update this doc to indicate that), please use our own fork of lighteval from the [\`eldar-fix-litellm\` branch](https://github.com/neuralmagic/lighteval/tree/eldar-fix-litellm)
+To use lighteval with a vLLM server, use the litellm endpoint.
 
-To use lighteval with a vLLM server, one needs to use the litellm endpoint as follows.
+**litellm_config.yaml**
 
-## Create yaml file containing configuration for evaluation
-
-**litellm\_config.yaml**
-
-```
+```yaml
 model_parameters:
   provider: "hosted_vllm"
   model_name: "hosted_vllm/<model_name>"
   base_url: "http://0.0.0.0:8000/v1"
   api_key: ""
   timeout: 1200
-  max_model_lentgh: 96000
   concurrent_requests: 16
   generation_parameters:
     temperature: 0.6
@@ -48,50 +46,49 @@ model_parameters:
 
 **Notes:**
 
-* The model\_name has to be preceded by “hosted\_vllm”. Examples:  
-  * HF model: moonshotai/Kimi-K2-Thinking  
-    * model\_name: “hosted\_vllm/moonshotai/Kimi-K2-Thinking”  
-  * Local model: /local-dir  
-    * model\_name: “hosted\_vllm/local-dir”  
-* Generation parameters (temperature, top\_p, top\_k, etc) should match the parameters suggested by the model provider, normally listed in the model card and/or *generation\_config.json*.  
-* max\_model\_length needs to be specified if the model’s default length is overridden when launching the vLLM server.  
-* lighteval allows generating multiple responses per sample, each using a different seed. This is useful when repeating the same evaluation is needed (see syntax below). If using this, each request will spin multiple decoding processes within vLLM. Be mindful of that when determining concurrent\_requests.  
-* The seed is specified in the generation\_parameters.  
-* The timeout parameter controls the time in seconds per request. This is optional, but I recommend setting it to a large number for reasoning evals.  
-* Default value for concurrent\_requests is low (10), so feel free to increase concurrency for better speed.
+- The model_name must be preceded by `hosted_vllm`. Examples:
+  - HF model: `moonshotai/Kimi-K2-Thinking` → `model_name: "hosted_vllm/moonshotai/Kimi-K2-Thinking"`
+  - Local model: `/local-dir` → `model_name: "hosted_vllm/local-dir"`
+- Generation parameters should match the model provider's recommendations.
+- `max_model_length` needs to be specified if the model's default length is overridden when launching the vLLM server.
+- lighteval allows generating multiple responses per sample, each with a different seed. Set `concurrent_requests` accordingly.
+- The seed is specified in `generation_parameters`.
+- The timeout parameter controls time in seconds per request.
+- Default `concurrent_requests` is low (10); increase for better throughput.
 
-## Evaluation command
+**Evaluation command:**
 
 ```shell
 lighteval endpoint litellm litellm_config.yaml \
-"aime25@<k>@<n>|0,math_500@<k>@<n>|0" \
---output-dir <output-dir> \
---save-details
+  "aime25@<k>@<n>|0,math_500@<k>@<n>|0" \
+  --output-dir <output-dir> \
+  --save-details
 ```
 
-   
-Notes:
+**Notes:**
 
-* Tasks are specified as: \<task\_name\>@\<k\>@\<n\>|\<num\_fewshot\>. In previous versions there was a need to specify an additional \<suite\> entry (\<suite\>|\<task\_name\>|\<num\_fewshot\>) that is now deprecated. Examples  
-  * aime25@1@8|0  
-  * math\_500@1@3|0  
-  * gpqa:diamond@1@3|0  
-* k and n refer to pass@k with n samples.  
-  * This can be used to average results over multiple random seeds. For instance, setting k=1 and n=3 will average the results over 3 different random seeds.  
-  * If k and n are not specified, they default to k=1 and n=1.  
-* If you are running evals in a loop and need to change some values in *litellm\_config.yaml*, instead of creating a new yaml file for each new configuration, you can also use an inline string instead of the yaml file as an input. For example: 
+- Task format: `<task_name>@<k>@<n>|<num_fewshot>`. If k and n are omitted, they default to 1.
+  - `aime25@1@8|0` — 8 seeds, pass@1
+  - `math_500@1@3|0` — 3 seeds, pass@1
+  - `gpqa:diamond@1@3|0` — 3 seeds
+- k and n refer to pass@k with n samples; used to average results over multiple seeds.
+- Inline string alternative (useful in scripts):
 
 ```shell
 lighteval endpoint litellm \
-"model_name=hosted_vllm/${SERVED_MODEL_NAME},provider=hosted_vllm,base_url=http://0.0.0.0:${PORT}/v1,timeout=3600,concurrent_requests=8,generation_parameters={temperature:${TEMP},max_new_tokens:${MAX_NEW_TOKENS},top_p:${TOP_P},seed:${SEED},presence_penalty:${PRESENCE_PENALTY},top_k:${TOP_K},min_p:${MIN_P},repetition_penalty:${REPETITION_PENALTY}}" \
-"aime25@k=${K}@n=${N_AIME}|0,math_500@k=${K}@n=${N_OTHERS}|0,gpqa:diamond@k=${K}@n=${N_OTHERS}|0,lcb:codegeneration_v6|0" \
---output-dir ${OUTPUT_DIR} \
---save-details
+  "model_name=hosted_vllm/${SERVED_MODEL_NAME},provider=hosted_vllm,base_url=http://0.0.0.0:${PORT}/v1,timeout=3600,concurrent_requests=8,generation_parameters={temperature:${TEMP},max_new_tokens:${MAX_NEW_TOKENS},top_p:${TOP_P},seed:${SEED},top_k:${TOP_K}}" \
+  "aime25@k=${K}@n=${N_AIME}|0,math_500@k=${K}@n=${N_OTHERS}|0,gpqa:diamond@k=${K}@n=${N_OTHERS}|0,lcb:codegeneration_v6|0" \
+  --output-dir ${OUTPUT_DIR} \
+  --save-details
 ```
 
-# lm-eval generative tasks
+---
 
-## Evaluation command
+## lm-eval (generative tasks)
+
+**Note:** use the neuralmagic fork: https://github.com/neuralmagic/lm-evaluation-harness
+
+**Evaluation command:**
 
 ```shell
 lm_eval --model local-chat-completions \
@@ -107,17 +104,12 @@ lm_eval --model local-chat-completions \
 
 **Notes:**
 
-* MUST set max\_length explicitly (default=2048 is very low).  
-* Greedy decoding is the default. MUST set gen\_kwargs if one wishes to use something other than greedy (and must set do\_sample to True explicitly).  
-* Generation parameters (temperature, top\_p, top\_k, etc) should match the parameters suggested by the model provider, normally listed in the model card and/or *generation\_config.json*.  
-* Seed MUST be included in the gen\_kwargs. Right now lm-eval does not pipe the seed correctly to the vLLM request.  
-* Default num\_concurrent requests is low (10), so feel free to increase concurrency for better speed.  
-* The timeout parameter controls the time in seconds per request. This is optional, but I recommend setting it to a large number for reasoning evals.  
-* DOES NOT WORK with log-likelihood tasks (or output\_type: multiple\_choice in lm-eval definitions). Only works for generative tasks.
+- Always set `max_length` explicitly (the default of 2048 is very low).
+- Set `do_sample=True` explicitly when using non-greedy decoding.
+- Include `seed` in both `--seed` and `gen_kwargs`.
+- Only works with generative tasks; does not work with log-likelihood or multiple-choice tasks.
 
-# lm-eval multiple-choice tasks (no support for chat template)
-
-## Evaluation command
+## lm-eval (multiple-choice tasks, no chat template)
 
 ```
 lm_eval --model local-completions \
@@ -127,17 +119,10 @@ lm_eval --model local-completions \
   --output_path results_mmlu.json
 ```
 
-**Notes:**
+## Debugging tips
 
-* MUST set max\_length explicitly (default=2048 is very low).  
-* Default num\_concurrent requests is 1, so feel free to increase concurrency for better speed.
-
-# Useful debugging tips
-
-* Launch limited evaluations for debugging before committing to complete (expensive) evaluations  
-  * With lighteval use the argument \--max-samples 5  
-  * With lm-eval use the argument \--limit 5  
-* Sometimes eval libraries might silently ignore some of your sampling arguments because they are either not parsed correctly or not propagated properly to the actual API call. Before running large scale evaluations, we advise doing a quick debugging run to confirm that all sampling arguments are handled correctly. To do this, start your vLLM server with the following flags:
+- Limit samples for quick tests: `--max-samples 5` (lighteval) or `--limit 5` (lm-eval)
+- Verify sampling args reach vLLM:
 
 ```shell
 VLLM_LOGGING_LEVEL=INFO vllm serve <model> \
@@ -145,129 +130,161 @@ VLLM_LOGGING_LEVEL=INFO vllm serve <model> \
     --uvicorn-log-level info
 ```
 
-and verify if your sampling args are correctly reaching the v	LLM server:
+---
+
+# Standard benchmarks
+
+## Standard protocol
+
+- Always use the chat template (`--apply_chat_template`)
+- Use `--fewshot_as_multiturn` when using 1 or more few-shot examples
+- Match generation parameters to the model provider's recommendations
+- Each benchmark entry lists the recommended number of repetitions (runs with different random seeds)
+- For lighteval, use `@1@n` to denote average over n repetitions. Example: AIME 2025 with 8 repetitions: `aime25@1@8`
+
+---
+
+## Instruction Following
+
+### GSM8K Platinum
+
+- **Harness:** lm-eval
+- **Task:** `gsm8k_platinum_cot_llama`
+- **Shots:** 5
+- **Metric:** `exact_match,strict-match`
+- **Repetitions:** 3
+
+### MMLU-CoT
+
+- **Harness:** lm-eval
+- **Task:** `mmlu_cot_llama`
+- **Shots:** 5
+- **Metric:** `exact_match,strict_match`
+- **Repetitions:** 3
+
+### MMLU-Pro
+
+- **Harness:** lm-eval (neuralmagic fork)
+- **Task:** `mmlu_pro_chat`
+- **Shots:** 5
+- **Metric:** `exact_match,custom-extract`
+- **Repetitions:** 3
+
+### IFEval
+
+- **Harness:** lm-eval
+- **Task:** `ifeval`
+- **Shots:** 0
+- **Metrics:** `prompt_level_strict_acc` and `inst_level_strict_acc`
+- **Repetitions:** 3
+
+---
+
+## Reasoning
+
+### GSM8K Platinum
+
+- **Harness:** lm-eval
+- **Task:** `gsm8k_platinum_cot_llama`
+- **Shots:** 0
+- **Metric:** `exact_match,strict-match`
+- **Repetitions:** 3
+
+### MMLU-Pro
+
+- **Harness:** lm-eval (neuralmagic fork)
+- **Task:** `mmlu_pro_chat`
+- **Shots:** 0
+- **Metric:** `exact_match,custom-extract`
+- **Repetitions:** 3
+
+### IFEval
+
+- **Harness:** lm-eval
+- **Task:** `ifeval`
+- **Shots:** 0
+- **Metrics:** `prompt_level_strict_acc` and `inst_level_strict_acc`
+- **Repetitions:** 3
+
+### MATH-500
+
+- **Harness:** lighteval
+- **Task:** `math_500`
+- **Shots:** 0
+- **Metric:** `pass@k:k=1&n=1`
+- **Repetitions:** 3
+
+### AIME 2025
+
+- **Harness:** lighteval
+- **Task:** `aime25`
+- **Shots:** 0
+- **Metric:** `pass@k:k=1&n=1`
+- **Repetitions:** 8
+
+### GPQA Diamond
+
+- **Harness:** lighteval
+- **Task:** `gpqa:diamond`
+- **Shots:** 0
+- **Metric:** `gpqa_pass@k:k=1`
+- **Repetitions:** 3
+
+---
+
+## Coding
+
+### LiveCodeBench v6
+
+- **Harness:** lighteval
+- **Task:** `lcb:codegeneration_v6`
+- **Shots:** 0
+- **Metric:** `codegen_pass@1:16`
+- **Repetitions:** 3
+
+---
+
+## Tool Calling
+
+### BFCLv4
+
+- **Tool:** Berkeley Function Call Leaderboard CLI (`bfcl`)
+- **When to include:** For models with tool-calling support, when BFCL results are available.
+- **Test category:** `all`
+- **Reported sub-scores:**
+  - **Overall** (weighted composite)
+  - **Single Turn** (Non-Live AST Accuracy)
+  - **Multi-Turn**
+  - **Agentic**
+- **Scoring weights:** Non-Live=10, Live=10, Irrelevance=10, Multi-Turn=30, Agentic=40
+  - Agentic = unweighted average of web_search and memory categories
+  - Overall = weighted sum of all categories divided by 100
+- **Repetitions:** 1 (BFCL is deterministic for a fixed model)
+
+### Where to find results
+
+BFCL scores may be in several locations depending on how the evaluation was run:
+
+- `score/data_overall.csv` — unquantized model scores
+- `score/quantized/data_overall.csv` — quantized model scores (may not exist)
+- Per-category JSON files under `score/` — needed to compute sub-scores when
+  the CSV does not contain them
+
+If results cannot be located automatically, prompt the user for the path to the
+BFCL score directory.
+
+The Overall score is typically pre-computed in the CSV. Sub-scores may require
+reading per-category JSON files and applying the scoring weights above.
+
+### Registration (for running new evaluations)
+
+1. Add a `ModelConfig` entry to `bfcl_eval/constants/model_config.py` under `api_inference_model_map`.
+2. Add the model key to the `SUPPORTED_MODELS` list in `bfcl_eval/constants/supported_models.py`.
+3. The model slug must match `--served-model-name` passed to vLLM (or the HuggingFace repo path by default).
+
+### Commands
 
 ```shell
-(APIServer pid=953522) INFO 03-20 05:36:49 [logger.py:49] Received request chatcmpl-96ec1b6b48833ca1: params: SamplingParams(n=1, presence_penalty=1.5, frequency_penalty=0.0, repetition_penalty=1.3, temperature=1.0, top_p=0.95, top_k=18, min_p=0.23, seed=42, stop=[], stop_token_ids=[], bad_words=[], include_stop_str_in_output=False, ignore_eos=False, max_tokens=65536, min_tokens=0, logprobs=None, prompt_logprobs=None, skip_special_tokens=True, spaces_between_special_tokens=True, truncate_prompt_tokens=None, structured_outputs=None, extra_args=None)
+bfcl generate --model <MODEL_SLUG> --test-category all
+bfcl evaluate --model <MODEL_SLUG> --test-category all
 ```
-
-# Standard evaluations
-
-# Standard protocol
-
-* Always use the chat template  
-* Use fewshot\_as\_multiturn when using 1 or more fewshot examples  
-* Use the vllm serve interface described in the General instructions tab  
-* Adjust generation configurations to match the model standard (temperature, top\_p, etc)  
-* The list below includes the number of suggested repetitions for each evaluation. Each repetition should use a different random seed  
-* For lighteval use **@1@n** to denote average over n repetitions. Example: AIME25 with 8 repetitions: aime25@1@8
-
-# Instruction following
-
-* GSM8k-Platinum  
-  * Harness: **lm-eval**  
-  * Task: **gsm8k\_platinum\_cot\_llama**  
-    * Can be used with models other than Llama too  
-  * Number of shots: **5**  
-  * Metric: **exact\_match,strict-match**  
-  * Repetitions: **3**  
-* MMLU-CoT  
-  * Harness: **lm-eval**  
-  * Task: **mmlu\_cot\_llama**  
-  * Number of shots: **5**  
-  * Metric: **exact\_match,strict\_match**  
-  * Repetitions: **3**  
-* MMLU-Pro  
-  * Harness: **lm-eval**  
-  * Task: **mmlu\_pro\_chat**  
-    * Only available on fork at the moment: [https://github.com/neuralmagic/lm-evaluation-harness/tree/mmlu-pro-chat-variant](https://github.com/neuralmagic/lm-evaluation-harness/tree/mmlu-pro-chat-variant)  
-  * Number of shots: **5**  
-  * Metric: **exact\_match,custom-extract**  
-  * Repetitions: **3**  
-* IFEval  
-  * Harness: **lm-eval**  
-  * Task: **ifeval**  
-  * Number of shots: **0**  
-  * Metric: **inst\_level\_strict\_acc,none**  
-  * Repetitions: **3**  
-* Math 500  
-  * Harness: **lighteval**  
-  * Task: **math\_500**  
-  * Number of shots: **0**  
-  * Metric:  
-    * 3 individual jobs: **pass@k:k=1\&n=1**  
-    * 1 single job: **pass@k:k=1\&n=3**  
-  * Repetitions: **3**  
-    * Either 3 individual jobs with different seeds or 1 single job with k=1, n=3
-
-# Reasoning
-
-* GSM8k-Platinum  
-  * Harness: **lm-eval**  
-  * Task: **gsm8k\_platinum\_cot\_llama**  
-    * Can be used with models other than Llama too  
-  * Number of shots: **0**  
-  * Metric: **exact\_match,strict-match**  
-  * Repetitions: **3**  
-* MMLU-Pro  
-  * lHarness: **lm-eval**  
-  * Task: **mmlu\_pro\_chat**  
-    * Only available on fork at the moment: [https://github.com/neuralmagic/lm-evaluation-harness/tree/mmlu-pro-chat-variant](https://github.com/neuralmagic/lm-evaluation-harness/tree/mmlu-pro-chat-variant)  
-  * Number of shots: **0**  
-  * Metric: **exact\_match,custom-extract**  
-  * Repetitions: **3**  
-* IFEval  
-  * Harness: **lm-eval**  
-  * Task: **ifeval**  
-  * Number of shots: **0**  
-  * Metric: **inst\_level\_strict\_acc,none**  
-  * Repetitions: **3**  
-* Math 500  
-  * Harness: **lighteval**  
-  * Task: **math\_500**  
-  * Number of shots: **0**  
-  * Metric:  
-    * 3 individual jobs: **pass@k:k=1\&n=1**  
-    * 1 single job: **pass@k:k=1\&n=1**  
-  * Repetitions: **3**  
-    * Either 3 individual jobs with different seeds or 1 single job with k=1, n=3  
-* AIME 25  
-  * Harness: **lighteval**  
-  * Task: **aime25**  
-  * Number of shots: **0**  
-  * Metric:  
-    * 8 individual jobs: **pass@k:k=1\&n=1**  
-    * 1 single job: **pass@k:k=1\&n=8**  
-  * Repetitions: **8**  
-    * Either 8 individual jobs with different seeds or 1 single job with k=1, n=8  
-* GPQA Diamond  
-  * Harness: **lighteval**  
-  * Task: **gpqa:diamond**  
-  * Number of shots: **0**  
-  * Metric:  
-    * 3 individual jobs: **gpqa\_pass@k:k=1\&n=1**  
-    * 1 single job: **gpqa\_pass@k:k=1\&n=3**  
-  * Repetitions: **3**  
-    * Either 3 individual jobs with different seeds or 1 single job with k=1, n=3
-
-# Coding
-
-* LiveCodeBench v6  
-  * Harness: **lighteval**  
-  * Task: **lcb:codegeneration\_v6**  
-  * Number of shots: **0**  
-  * Metric:  
-    * 3 individual jobs: **codegen\_pass@k:k=1\&n=1**  
-    * 1 single job: **codegen\_pass@k:k=1\&n=3**  
-  * Repetitions: **3**  
-    * Either 3 individual jobs with different seeds or 1 single job with k=1, n=3  
-* SWE-Bench  
-  * swe-bench \+ mini-swe-agent  
-  * Lite  
-  * Will share more information about how to use it in coming days
-
-# Long context
-
-* MRCR  
-  * Custom evaluation harness  
-  * Will add more information in coming days

--- a/ai_skills/huggingface/create-model-card-compression/template.md
+++ b/ai_skills/huggingface/create-model-card-compression/template.md
@@ -53,11 +53,14 @@ base_model: <ORIGINAL_MODEL_ID>
 # <QUANTIZED_MODEL_NAME>
 
 ## Model Overview
-- **Model Architecture:** <ORIGINAL_MODEL_ID>
+- **Model Architecture:** <ARCHITECTURE_CLASS>
+<!-- ARCHITECTURE_CLASS: the class name from config.json's architectures[0] field,
+     e.g. LlamaForCausalLM, Gemma4ForConditionalGeneration, Qwen2ForCausalLM
+     NOT the HuggingFace model ID or _name_or_path -->
   - **Input:** <MODEL_INPUT>
   - **Output:** <MODEL_OUTPUT>
 <!-- MODEL_INPUT and MODEL_OUTPUT are usually "Text" / "Text".
-     For multimodal models adjust accordingly (e.g. "Text/Image" / "Text"). -->
+     For multimodal models adjust accordingly (e.g. "Text / Image" / "Text"). -->
 - **Model Optimizations:**
   - **Weight quantization:** <WEIGHT_QUANT_TYPE>
   - **Activation quantization:** <ACTIVATION_QUANT_TYPE>
@@ -108,7 +111,13 @@ This optimization reduces the number of bits per parameter from 16 to <BITS_PER_
        16 -> 4 bits  = ~75% reduction
        For mixed precision, compute based on the average bits. -->
 
-Only the weights and activations of the linear operators within transformers blocks are quantized using [LLM Compressor](https://github.com/vllm-project/llm-compressor).
+<!-- IF weights AND activations are quantized (INT W8A8, FP8 W8A8, FP8 W8A8 block, NVFP4, Mixed) -->
+Only the weights and activations of the linear operators within transformer blocks are quantized using [LLM Compressor](https://github.com/vllm-project/llm-compressor).
+<!-- ENDIF -->
+
+<!-- IF only weights are quantized (INT W4A16) -->
+Only the weights of the linear operators within transformer blocks are quantized using [LLM Compressor](https://github.com/vllm-project/llm-compressor).
+<!-- ENDIF -->
 
 <!-- ============================================================
      SECTION 4: DEPLOYMENT
@@ -118,15 +127,21 @@ Only the weights and activations of the linear operators within transformers blo
 
 ### Use with vLLM
 
-1. Initialize vLLM server:
+1. Start the vLLM server:
 ```
 vllm serve RedHatAI/<QUANTIZED_MODEL_NAME> <VLLM_EXTRA_ARGS>
 ```
-<!-- VLLM_EXTRA_ARGS: include flags relevant to the model, for example:
-       --tensor_parallel_size N
+<!-- VLLM_EXTRA_ARGS: use flags from the vLLM recipes page for this model
+     (https://recipes.vllm.ai/<ORG>/<BASE_MODEL_NAME>) as the primary reference,
+     supplemented by the base model's HuggingFace README. Include only flags
+     relevant to the model, for example:
+       --reasoning-parser         (for reasoning models)
+       --tool-call-parser         (for tool-calling models)
+       --enable-auto-tool-choice  (for tool-calling models)
+       --chat-template <path>     (when a custom chat template was used)
        --tokenizer_mode mistral   (if the model uses a Mistral tokenizer)
-       --max_model_len N          (if needed)
-     Adjust based on the specific model's requirements. -->
+       --max_model_len N          (if specified in the base model card)
+     Do not add --tensor_parallel_size unless the base model card prescribes it. -->
 
 2. Send requests to the server:
 
@@ -155,6 +170,9 @@ outputs = client.chat.completions.create(
 generated_text = outputs.choices[0].message.content
 print(generated_text)
 ```
+<!-- For model-specific request parameters (thinking mode, tool calling format,
+     sampling settings), refer to the vLLM recipes page for this model:
+     https://recipes.vllm.ai/<ORG>/<BASE_MODEL_NAME> -->
 
 <!-- ============================================================
      SECTION 5: CREATION
@@ -162,7 +180,10 @@ print(generated_text)
 
 ## Creation
 
-This model was created by applying [LLM Compressor](https://github.com/vllm-project/llm-compressor) with calibration samples from UltraChat, as presented in the code snippet below.
+This model was created by applying [LLM Compressor](https://github.com/vllm-project/llm-compressor) with calibration samples from <CALIBRATION_DATASET>, as presented in the code snippet below.
+<!-- CALIBRATION_DATASET: set to the dataset used in the quantization script (e.g. UltraChat).
+     If the quantization scheme requires no calibration data (e.g. FP8 dynamic),
+     omit the "with calibration samples from ..." phrase entirely and use model_free_ptq(). -->
 
 <details>
 
@@ -176,11 +197,11 @@ This model was created by applying [LLM Compressor](https://github.com/vllm-proj
        - Configuring the quantization recipe (varies by format):
            INT W8A8       -> GPTQModifier or QuantizationModifier with int8 weights + int8 activations
            INT W4A16      -> GPTQModifier with int4 weights, group_size 128, no activation quantization
-           FP8 W8A8       -> QuantizationModifier with fp8 weights + dynamic per-tensor fp8 activations
-           FP8 W8A8 block -> QuantizationModifier with fp8 weights + fp8 activations using block scales (group_size 128)
-           NVFP4          -> SmoothQuantModifier + QuantizationModifier with fp4 weights + fp4 activations, group_size 16
+           FP8 W8A8       -> model_free_ptq(scheme="FP8_DYNAMIC") — no calibration data needed
+           FP8 W8A8 block -> QuantizationModifier with fp8 weights + fp8 block-scaled activations (group_size 128)
+           NVFP4          -> QuantizationModifier with scheme="NVFP4", fp4 weights + fp4 activations, group_size 16
            Mixed          -> recipe with per-layer config mapping layers to different precisions
-       - Running oneshot() to apply quantization
+       - Running oneshot() or apply() to apply quantization
        - Saving the model in compressed-tensors format
 -->
 </details>
@@ -193,30 +214,32 @@ This model was created by applying [LLM Compressor](https://github.com/vllm-proj
 
 <!-- Add a sentence listing the benchmarks the model was evaluated on and the
      evaluation harnesses used. Mention both lm-evaluation-harness and lighteval
-     if both were used. Link to the relevant repos.
+     if both were used. Mention BFCLv4 if tool-calling results are available.
+     Only list benchmarks for which results are present.
 
-     Example: "This model was evaluated on GSM8k-Platinum, MMLU-CoT, IFEval, and
-     Math 500 using lm-evaluation-harness and lighteval."
-
-     Refer to the evaluation protocol document (model_cards/Evaluations using vLLM server.md)
-     for the full list of standard benchmarks, harness configurations, and commands. -->
+     Example: "This model was evaluated on GSM8K Platinum, MMLU-Pro, IFEval,
+     MATH-500, AIME 2025, GPQA Diamond, LiveCodeBench v6, and BFCLv4 using
+     lm-evaluation-harness, lighteval, and BFCL — all served with vLLM
+     (OpenAI-compatible API)." -->
 
 <EVALUATION_DESCRIPTION>
 
 ### Accuracy
 
-<!-- Add an HTML table with evaluation results.
-     Columns: Category | Metric | <ORIGINAL_MODEL_ID> | RedHatAI/<QUANTIZED_MODEL_NAME> | Recovery
-     Recovery = (quantized_score / original_score) * 100, shown as percentage.
-     Group rows by category using rowspan. Include an Average row per category.
+<!-- IF results are available for both thinking and non-thinking modes:
+     use two subsections as shown below.
+     IF only one set of results is available:
+     present a single table without the subsection headers. -->
 
-     Example: -->
+<!-- IF both thinking and non-thinking results are available -->
+#### Without thinking
+<!-- ENDIF -->
 
 <table>
   <thead>
     <tr>
       <th>Category</th>
-      <th>Metric</th>
+      <th>Benchmark</th>
       <th><ORIGINAL_MODEL_ID></th>
       <th>RedHatAI/<QUANTIZED_MODEL_NAME></th>
       <th>Recovery</th>
@@ -224,33 +247,157 @@ This model was created by applying [LLM Compressor](https://github.com/vllm-proj
   </thead>
   <tbody>
     <tr>
-      <td rowspan="4"><b>Instruction Following</b></td>
-      <td>GSM8k-Platinum (5-shot)</td>
+      <td rowspan="2"><b>Instruction Following</b></td>
+      <td>IFEval (0-shot, prompt-level strict)</td>
       <td><!-- original score --></td>
       <td><!-- quantized score --></td>
       <td><!-- recovery % --></td>
     </tr>
     <tr>
-      <td>MMLU-CoT (5-shot)</td>
+      <td>IFEval (0-shot, inst-level strict)</td>
       <td><!-- original score --></td>
       <td><!-- quantized score --></td>
       <td><!-- recovery % --></td>
     </tr>
     <tr>
-      <td>IFEval (0-shot)</td>
+      <td rowspan="5"><b>Reasoning</b></td>
+      <td>GSM8K Platinum (0-shot, strict-match)</td>
       <td><!-- original score --></td>
       <td><!-- quantized score --></td>
       <td><!-- recovery % --></td>
     </tr>
     <tr>
-      <td><b>Average</b></td>
-      <td><b><!-- avg original --></b></td>
-      <td><b><!-- avg quantized --></b></td>
-      <td><b><!-- avg recovery --></b></td>
+      <td>MMLU-Pro (0-shot, custom-extract)</td>
+      <td><!-- original score --></td>
+      <td><!-- quantized score --></td>
+      <td><!-- recovery % --></td>
     </tr>
-    <!-- Add more categories and rows as needed (Reasoning, Coding, etc.) -->
+    <tr>
+      <td>MATH-500 (0-shot, pass@1)</td>
+      <td><!-- original score --></td>
+      <td><!-- quantized score --></td>
+      <td><!-- recovery % --></td>
+    </tr>
+    <tr>
+      <td>AIME 2025 (0-shot, pass@1)</td>
+      <td><!-- original score --></td>
+      <td><!-- quantized score --></td>
+      <td><!-- recovery % --></td>
+    </tr>
+    <tr>
+      <td>GPQA Diamond (0-shot, pass@1)</td>
+      <td><!-- original score --></td>
+      <td><!-- quantized score --></td>
+      <td><!-- recovery % --></td>
+    </tr>
+    <tr>
+      <td><b>Coding</b></td>
+      <td>LiveCodeBench v6 (0-shot, pass@1)</td>
+      <td><!-- original score --></td>
+      <td><!-- quantized score --></td>
+      <td><!-- recovery % --></td>
+    </tr>
+    <!-- Add or remove rows to match the benchmarks actually evaluated -->
   </tbody>
 </table>
+
+<!-- IF both thinking and non-thinking results are available -->
+#### With thinking
+
+<table>
+  <thead>
+    <tr>
+      <th>Category</th>
+      <th>Benchmark</th>
+      <th><ORIGINAL_MODEL_ID></th>
+      <th>RedHatAI/<QUANTIZED_MODEL_NAME></th>
+      <th>Recovery</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td rowspan="2"><b>Instruction Following</b></td>
+      <td>IFEval (0-shot, prompt-level strict)</td>
+      <td><!-- original score --></td>
+      <td><!-- quantized score --></td>
+      <td><!-- recovery % --></td>
+    </tr>
+    <tr>
+      <td>IFEval (0-shot, inst-level strict)</td>
+      <td><!-- original score --></td>
+      <td><!-- quantized score --></td>
+      <td><!-- recovery % --></td>
+    </tr>
+    <tr>
+      <td rowspan="5"><b>Reasoning</b></td>
+      <td>GSM8K Platinum (0-shot, strict-match)</td>
+      <td><!-- original score --></td>
+      <td><!-- quantized score --></td>
+      <td><!-- recovery % --></td>
+    </tr>
+    <tr>
+      <td>MMLU-Pro (0-shot, custom-extract)</td>
+      <td><!-- original score --></td>
+      <td><!-- quantized score --></td>
+      <td><!-- recovery % --></td>
+    </tr>
+    <tr>
+      <td>MATH-500 (0-shot, pass@1)</td>
+      <td><!-- original score --></td>
+      <td><!-- quantized score --></td>
+      <td><!-- recovery % --></td>
+    </tr>
+    <tr>
+      <td>AIME 2025 (0-shot, pass@1)</td>
+      <td><!-- original score --></td>
+      <td><!-- quantized score --></td>
+      <td><!-- recovery % --></td>
+    </tr>
+    <tr>
+      <td>GPQA Diamond (0-shot, pass@1)</td>
+      <td><!-- original score --></td>
+      <td><!-- quantized score --></td>
+      <td><!-- recovery % --></td>
+    </tr>
+    <tr>
+      <td><b>Coding</b></td>
+      <td>LiveCodeBench v6 (0-shot, pass@1)</td>
+      <td><!-- original score --></td>
+      <td><!-- quantized score --></td>
+      <td><!-- recovery % --></td>
+    </tr>
+    <!-- IF BFCLv4 results are available -->
+    <tr>
+      <td rowspan="4"><b>Tool Calling</b></td>
+      <td>BFCLv4 Overall</td>
+      <td><!-- baseline % --></td>
+      <td><!-- quantized % --></td>
+      <td><!-- recovery % --></td>
+    </tr>
+    <tr>
+      <td>BFCLv4 Single Turn</td>
+      <td><!-- baseline % --></td>
+      <td><!-- quantized % --></td>
+      <td><!-- recovery % --></td>
+    </tr>
+    <tr>
+      <td>BFCLv4 Multi-Turn</td>
+      <td><!-- baseline % --></td>
+      <td><!-- quantized % --></td>
+      <td><!-- recovery % --></td>
+    </tr>
+    <tr>
+      <td>BFCLv4 Agentic</td>
+      <td><!-- baseline % --></td>
+      <td><!-- quantized % --></td>
+      <td><!-- recovery % --></td>
+    </tr>
+    <!-- BFCLv4 scores shown as percentages (e.g. 68.31%), not plain numbers -->
+    <!-- ENDIF BFCLv4 -->
+    <!-- Add or remove rows to match the benchmarks actually evaluated -->
+  </tbody>
+</table>
+<!-- ENDIF both thinking and non-thinking -->
 
 ### Reproduction
 
@@ -258,39 +405,92 @@ The results were obtained using the following commands:
 
 <!-- Add the evaluation commands inside a collapsible <details> block.
      Include one command block per benchmark evaluated.
-     Refer to model_cards/Evaluations using vLLM server.md for the standard
-     command formats, harness selection (lm-eval vs lighteval), number of shots,
-     and repetition settings for each benchmark.
-
-     Two examples are shown below — one for lm-eval (generative tasks via vLLM server)
-     and one for lighteval. Adapt the model name, generation parameters, and
-     task names to match the actual evaluations run. -->
+     Refer to evaluations.md for standard command formats, harness selection
+     (lm-eval vs lighteval), and task names for each benchmark.
+     Only include commands for benchmarks that were actually evaluated. -->
 
 <details>
 
-#### GSM8k-Platinum (lm-eval, 5-shot, 3 repetitions)
+#### GSM8K Platinum (lm-eval, 0-shot, 3 repetitions)
 ```
 lm_eval --model local-chat-completions \
   --tasks gsm8k_platinum_cot_llama \
-  --model_args "model=RedHatAI/<QUANTIZED_MODEL_NAME>,max_length=<MAX_LENGTH>,base_url=http://0.0.0.0:8000/v1/chat/completions,num_concurrent=128,max_retries=3,tokenized_requests=False,tokenizer_backend=None,timeout=1200" \
-  --num_fewshot 5 \
+  --model_args "model=RedHatAI/<QUANTIZED_MODEL_NAME>,max_length=<MAX_LENGTH>,base_url=http://0.0.0.0:8000/v1/chat/completions,num_concurrent=32,max_retries=3,tokenized_requests=False,tokenizer_backend=None,timeout=1200" \
+  --num_fewshot 0 \
   --apply_chat_template \
-  --fewshot_as_multiturn \
   --output_path results_gsm8k_platinum.json \
   --seed 1234 \
   --gen_kwargs "do_sample=True,temperature=<TEMPERATURE>,top_p=<TOP_P>,top_k=<TOP_K>,max_gen_toks=<MAX_GEN_TOKS>,seed=1234"
 ```
 
-#### Math 500 (lighteval, 0-shot, 3 repetitions)
-```
-lighteval endpoint litellm litellm_config.yaml \
-  "math_500@1@3|0" \
-  --output-dir <OUTPUT_DIR> \
-  --save-details
+#### MATH-500, AIME 2025, GPQA Diamond (lighteval, 3 repetitions; 8 for AIME 2025)
+
+**litellm_config.yaml:**
+```yaml
+model_parameters:
+  provider: hosted_vllm
+  model_name: hosted_vllm/RedHatAI/<QUANTIZED_MODEL_NAME>
+  base_url: http://0.0.0.0:8000/v1
+  api_key: ''
+  timeout: 3600
+  concurrent_requests: 32
+  generation_parameters:
+    temperature: <TEMPERATURE>
+    max_new_tokens: <MAX_NEW_TOKENS>
+    top_p: <TOP_P>
+    top_k: <TOP_K>
+    seed: 1234
 ```
 
-<!-- Add more command blocks for each benchmark evaluated.
-     Remember to repeat each evaluation with different seeds as specified
-     in the evaluation protocol. -->
+Run once per seed (changing `seed` in the config each time):
+```
+lighteval endpoint litellm litellm_config.yaml 'math_500|0' \
+  --output-dir results/ --save-details
+
+lighteval endpoint litellm litellm_config.yaml 'aime25|0' \
+  --output-dir results/ --save-details
+
+lighteval endpoint litellm litellm_config.yaml 'gpqa:diamond|0' \
+  --output-dir results/ --save-details
+```
+
+<!-- Add more command blocks for each benchmark evaluated. -->
+
+<!-- IF BFCLv4 results are present -->
+#### BFCLv4
+
+BFCL requires the model to be registered in the leaderboard codebase before running.
+
+**Step 1 — Register the model in `bfcl_eval/constants/model_config.py`**
+
+Add the following entry to `api_inference_model_map`:
+
+```python
+"<MODEL_SLUG>": ModelConfig(
+    model_name="<MODEL_SLUG>",
+    display_name="<DISPLAY_NAME> (FC)",
+    url="https://huggingface.co/RedHatAI/<QUANTIZED_MODEL_NAME>",
+    org="<ORG>",
+    license="<LICENSE>",
+    model_handler=OpenAICompletionsHandler,
+    input_price=None,
+    output_price=None,
+    is_fc_model=True,
+    underscore_to_dot=True,
+),
+```
+
+**Step 2 — Add the key to `bfcl_eval/constants/supported_models.py`**
+
+Add `"<MODEL_SLUG>"` to the `SUPPORTED_MODELS` list.
+
+**Step 3 — Start the vLLM server** (use the command at the top of this section)
+
+**Step 4 — Generate responses and evaluate**
+```
+bfcl generate --model <MODEL_SLUG> --test-category all
+bfcl evaluate --model <MODEL_SLUG> --test-category all
+```
+<!-- ENDIF BFCLv4 -->
 
 </details>


### PR DESCRIPTION
## Summary
  
  - **BFCLv4 support**: SKILL.md and template.md now handle tool-calling results —
    dual thinking/non-thinking accuracy tables, Tool Calling category rows (Overall,
    Single Turn, Multi-Turn, Agentic shown as percentages), multi-path score discovery,
    and BFCL registration + reproduction steps
  - **Score scripts**: compute_averages.py and compute_recovery.py added; SKILL.md
    steps 8 and 10 mandate their use instead of hand-parsing results
  - **evaluations.md rewrite**: restructured as a catalogue (not enforced protocol),
    clean markdown, full BFCLv4 section, SWE-Bench/MRCR placeholder entries removed
  - **template.md**: <ARCHITECTURE_CLASS> placeholder, conditional dual-table structure
    for thinking/non-thinking, data-free FP8 dynamic note, vLLM recipes page comment
  - **SKILL.md**: architectures[0] guidance, BFCL in evaluation intro, every_eval_ever
    upload note in Phase 6